### PR TITLE
Add chat demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Permitir a los usuarios visualizar información clave a través de KPIs y gráfi
 
 ## 🔐 Seguridad
 
-- Se prevé la integración de autenticación JWT.  
+- Se prevé la integración de autenticación JWT.
 - Actualmente, la aplicación no cuenta con control de sesiones seguro (uso limitado a entornos de pruebas).
+- Existe la página `/demo` para acceder a una versión de prueba del asistente. Desde allí se puede abrir la interfaz `/demo/chat`, similar a ChatGPT, para realizar consultas. Debe utilizarse únicamente en entornos de pruebas y no implementa control de sesiones seguro.
 
 ---
 

--- a/SAPAssistant/Pages/Chat/DemoChat.razor
+++ b/SAPAssistant/Pages/Chat/DemoChat.razor
@@ -1,0 +1,121 @@
+@page "/demo/chat"
+@attribute [AllowAnonymous]
+@layout PublicLayout
+@using Microsoft.AspNetCore.Components.Web
+@using SAPAssistant.Components.Chat
+@using SAPAssistant.Models.Chat
+@using SAPAssistant.Service
+@using SAPAssistant.Models
+@inject IJSRuntime JS
+@inject AssistantService AssistantService
+
+<div class="chat-content-full">
+    <div class="messages" @ref="messagesContainer">
+        @foreach (var msg in Messages)
+        {
+            <DynamicComponent Type="@GetComponentType(msg)" Parameters="GetParameters(msg)" />
+        }
+    </div>
+
+    <div class="input-area">
+        <SearchBar @bind-SearchText="UserInput" OnSearch="SendMessage" Disabled="isProcessing" />
+        @if (isProcessing)
+        {
+            <div class="loading-spinner">⌛ Procesando...</div>
+        }
+    </div>
+</div>
+
+@code {
+    private string UserInput { get; set; } = string.Empty;
+    private List<MessageBase> Messages { get; set; } = new();
+    private ElementReference messagesContainer;
+    private bool isProcessing = false;
+
+    private async Task SendMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message) || isProcessing) return;
+
+        isProcessing = true;
+        Messages.Add(new TextMessage
+            {
+                Content = message,
+                IsUser = true
+            });
+
+        try
+        {
+            var resultado = await AssistantService.ConsultarAsync(message);
+
+            if (resultado?.Tipo == "aclaracion" || resultado?.Tipo == "asistente")
+            {
+                Messages.Add(new TextMessage
+                    {
+                        IsUser = false,
+                        Content = resultado.Mensaje
+                    });
+            }
+            else if (resultado?.Tipo == "resumen")
+            {
+                Messages.Add(new TextMessage
+                    {
+                        IsUser = false,
+                        Content = resultado.Resumen
+                    });
+            }
+            else if (resultado?.Tipo == "system")
+            {
+                Messages.Add(new SystemMessage
+                    {
+                        Mensaje = resultado.Mensaje
+                    });
+            }
+            else
+            {
+                Messages.Add(new ResultMessage
+                    {
+                        IsUser = false,
+                        Resumen = resultado?.Resumen ?? string.Empty,
+                        Sql = resultado?.Sql ?? string.Empty,
+                        Resultados = resultado?.Resultados ?? new()
+                    });
+            }
+        }
+        catch (Exception ex)
+        {
+            Messages.Add(new ErrorMessage
+                {
+                    IsUser = false,
+                    Error = ex.Message
+                });
+        }
+
+        isProcessing = false;
+        await ScrollToBottom();
+    }
+
+    private async Task ScrollToBottom()
+    {
+        await JS.InvokeVoidAsync("chatEnhancer.scrollToBottom", messagesContainer);
+    }
+
+    private Type GetComponentType(MessageBase msg)
+    {
+        return msg.Type switch
+        {
+            "Text" => typeof(TextMessageComponent),
+            "Result" => typeof(ResultMessageComponent),
+            "Error" => typeof(ErrorMessageComponent),
+            "system" => typeof(SystemMessageComponent),
+            _ => typeof(TextMessageComponent)
+        };
+    }
+
+    private Dictionary<string, object> GetParameters(MessageBase msg)
+    {
+        return new()
+        {
+            ["Message"] = msg
+        };
+    }
+}

--- a/SAPAssistant/Pages/Chat/DemoChat.razor.css
+++ b/SAPAssistant/Pages/Chat/DemoChat.razor.css
@@ -1,0 +1,94 @@
+﻿.chat-content-full {
+    display: flex;
+    flex-direction: column;
+    height: 100vh; /* ✅ Toda la ventana de visualización */
+    background-color: #1e1e2f;
+    color: #e0e0e0;
+    padding: 0 20px;
+    overflow: hidden;
+}
+
+/* Mensajes */
+.messages {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 20px 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    scrollbar-width: thin;
+    scrollbar-color: #555 #2b2b3c;
+}
+
+    .messages::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .messages::-webkit-scrollbar-thumb {
+        background-color: #555;
+        border-radius: 4px;
+    }
+
+/* Área de Entrada */
+.input-area {
+    display: flex;
+    justify-content: center;
+    background-color: #1e1e2f;
+    padding: 20px;
+    border-top: 1px solid #333;
+    position: relative;
+    z-index: 10;
+}
+
+/* ✅ Sección de Resultados Dentro de Mensajes */
+.resultado-panel {
+    background-color: #2b2b3c;
+    border-radius: 16px;
+    padding: 20px;
+    margin: 20px 0; /* ✅ Espacio con respecto a los mensajes */
+    max-width: 800px;
+    align-self: center; /* ✅ Centra la sección dentro del flujo de mensajes */
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    color: #e0e0e0;
+}
+
+    .resultado-panel h3, .resultado-panel h4 {
+        color: #00bfa5;
+        margin-bottom: 10px;
+    }
+
+    .resultado-panel p {
+        margin-bottom: 15px;
+        line-height: 1.5;
+    }
+
+    .resultado-panel pre {
+        background-color: #1e1e2f;
+        padding: 15px;
+        border-radius: 8px;
+        overflow-x: auto;
+        color: #00bfa5;
+        font-family: Consolas, monospace;
+        font-size: 0.95rem;
+    }
+
+    .resultado-panel table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 15px;
+    }
+
+    .resultado-panel th, .resultado-panel td {
+        border: 1px solid #444;
+        padding: 10px;
+        text-align: left;
+    }
+
+    .resultado-panel th {
+        background-color: #333;
+        color: #00bfa5;
+    }
+
+    .resultado-panel tr:nth-child(even) {
+        background-color: #242433;
+    }

--- a/SAPAssistant/Pages/DemoLanding.razor
+++ b/SAPAssistant/Pages/DemoLanding.razor
@@ -1,0 +1,12 @@
+@page "/demo"
+@attribute [AllowAnonymous]
+@layout PublicLayout
+
+<div class="demo-landing">
+    <h1>Demo del Asistente</h1>
+    <p>
+        Esta página permite acceder a una versión de prueba del asistente. No implementa
+        un control de sesiones seguro, por lo que debe utilizarse únicamente en entornos de pruebas.
+    </p>
+    <a href="/demo/chat" class="demo-link">Ir a la interfaz de consulta</a>
+</div>

--- a/SAPAssistant/Pages/DemoLanding.razor.css
+++ b/SAPAssistant/Pages/DemoLanding.razor.css
@@ -1,0 +1,18 @@
+.demo-landing {
+    text-align: center;
+    padding: 2rem;
+}
+
+.demo-link {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 10px 20px;
+    background-color: #3b82f6;
+    color: white;
+    text-decoration: none;
+    border-radius: 6px;
+}
+
+.demo-link:hover {
+    background-color: #2563eb;
+}


### PR DESCRIPTION
## Summary
- connect `/demo` landing to new chat demo page
- implement `/demo/chat` using PublicLayout
- document how to access demo chat in README

## Testing
- `dotnet build SAPAssistant/SAPAssistant.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d627c658832089c242ddbd2c8abb