### PR TITLE
Support multiple result view types

### DIFF
--- a/SAPAssistant/Components/Chat/DemoChat.razor
+++ b/SAPAssistant/Components/Chat/DemoChat.razor
@@ -87,10 +87,11 @@
             else
             {
                 Messages.Add(new ResultMessage
-                    {                       
+                    {
                         Resumen = resultado?.Resumen ?? "",
                         Sql = resultado?.Sql ?? "",
-                        Data = resultado?.Resultados ?? new()
+                        Data = resultado?.Resultados ?? new(),
+                        ViewType = resultado?.ViewType ?? "grid"
                     });
             }
         }
@@ -108,15 +109,20 @@
         await JS.InvokeVoidAsync("chatEnhancer.scrollToBottom", messagesContainer);
     }
 
-    private Type GetComponentType(MessageBase msg) =>
-        msg.Type switch
-        {
-            "Text" => typeof(TextMessageComponent),
-            "Result" => typeof(ResultMessageComponent),
-            "Error" => typeof(ErrorMessageComponent),
-            "system" => typeof(SystemMessageComponent),
-            _ => typeof(TextMessageComponent)
-        };
+    private Type GetComponentType(MessageBase msg)
+        => msg.Type == "Result"
+            ? (((ResultMessage)msg).ViewType?.ToLower()) switch
+            {
+                "cards" => typeof(ResultCardListComponent),
+                _ => typeof(ResultGridComponent)
+            }
+            : msg.Type switch
+            {
+                "Text" => typeof(TextMessageComponent),
+                "Error" => typeof(ErrorMessageComponent),
+                "system" => typeof(SystemMessageComponent),
+                _ => typeof(TextMessageComponent)
+            };
 
     private Dictionary<string, object> GetParameters(MessageBase msg) =>
         new() { ["Message"] = msg };

--- a/SAPAssistant/Components/Chat/ResultCardListComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultCardListComponent.razor
@@ -1,0 +1,58 @@
+@using SAPAssistant.Models.Chat
+@inject IJSRuntime JS
+
+<link href="css/components/ChatMessages/resultmessage.css" rel="stylesheet" />
+
+<div class="resultado-panel">
+    <h3>🧠 Resumen generado</h3>
+    <p>@((MarkupString)M.Resumen)</p>
+
+    <div class="botones-acciones">
+        <button class="toggle-sql-btn" @onclick="() => MostrarSql = !MostrarSql">
+            @(MostrarSql ? "Ocultar consulta SQL" : "Ver consulta SQL")
+        </button>
+    </div>
+
+    @if (MostrarSql)
+    {
+        <div class="sql-block">
+            <button class="copy-btn" @onclick="CopiarSql" title="Copiar">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M10 1.5A1.5 1.5 0 0 1 11.5 3v10A1.5 1.5 0 0 1 10 14.5H4A1.5 1.5 0 0 1 2.5 13V4.707a1 1 0 0 1 .293-.707l3.207-3.207a1 1 0 0 1 .707-.293H10zm-1 1H7v2.5a.5.5 0 0 1-.5.5H4v7a.5.5 0 0 0 .5.5h5a.5.5 0 0 0 .5-.5v-10A.5.5 0 0 0 9 2.5z" />
+                </svg>
+            </button>
+            <pre>@M.Sql</pre>
+        </div>
+    }
+
+    @if (M.Data.Any())
+    {
+        <div class="card-list">
+            @foreach (var row in M.Data)
+            {
+                <div class="result-card">
+                    @foreach (var kv in row)
+                    {
+                        <div><strong>@kv.Key:</strong> @kv.Value</div>
+                    }
+                </div>
+            }
+        </div>
+    }
+    else
+    {
+        <p>No se encontraron resultados.</p>
+    }
+</div>
+
+@code {
+    [Parameter] public MessageBase Message { get; set; }
+    private ResultMessage M => (ResultMessage)Message;
+
+    private bool MostrarSql { get; set; } = false;
+
+    private async Task CopiarSql()
+    {
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", M.Sql);
+    }
+}

--- a/SAPAssistant/Components/Chat/ResultGridComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultGridComponent.razor
@@ -1,0 +1,134 @@
+﻿@using SAPAssistant.Models.Chat
+@inject IJSRuntime JS
+
+<link href="css/components/ChatMessages/resultmessage.css" rel="stylesheet" />
+
+<div class="resultado-panel">
+    <h3>🧠 Resumen generado</h3>
+    <p>@((MarkupString)M.Resumen)</p>
+
+    <div class="botones-acciones">
+        <button class="toggle-sql-btn" @onclick="() => MostrarSql = !MostrarSql">
+            @(MostrarSql ? "Ocultar consulta SQL" : "Ver consulta SQL")
+        </button>
+
+        @if (M.Data.Any())
+        {
+            <button class="export-btn" @onclick="ExportarCsv">⬇️ Exportar CSV</button>
+            <button class="copy-table-btn" @onclick="CopiarTabla">📋 Copiar tabla</button>
+        }
+    </div>
+
+    @if (MostrarSql)
+    {
+        <div class="sql-block">
+            <button class="copy-btn" @onclick="CopiarSql" title="Copiar">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M10 1.5A1.5 1.5 0 0 1 11.5 3v10A1.5 1.5 0 0 1 10 14.5H4A1.5 1.5 0 0 1 2.5 13V4.707a1 1 0 0 1 .293-.707l3.207-3.207a1 1 0 0 1 .707-.293H10zm-1 1H7v2.5a.5.5 0 0 1-.5.5H4v7a.5.5 0 0 0 .5.5h5a.5.5 0 0 0 .5-.5v-10A.5.5 0 0 0 9 2.5z" />
+                </svg>
+            </button>
+
+            @if (Copiado)
+            {
+                <div class="copiado-alert">✅ Copiada</div>
+            }
+
+            <pre>@M.Sql</pre>
+        </div>
+    }
+
+    @if (M.Data.Any())
+    {
+        <h4>📊 Resultados</h4>
+        <table class="table">
+            <thead>
+                <tr>
+                    @foreach (var col in M.Data[0].Keys)
+                    {
+                        <th>@col</th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var row in M.Data)
+                {
+                    <tr>
+                        @foreach (var val in row.Values)
+                        {
+                            <td>@val</td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+    else
+    {
+        <p>No se encontraron resultados.</p>
+    }
+</div>
+
+@code {
+    [Parameter] public MessageBase Message { get; set; }
+    private ResultMessage M => (ResultMessage)Message;
+
+    private bool MostrarSql { get; set; } = false;
+    private bool Copiado { get; set; } = false;
+
+    private async Task CopiarSql()
+    {
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", M.Sql);
+        Copiado = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        Copiado = false;
+        StateHasChanged();
+    }
+
+    private async Task CopiarTabla()
+    {
+        if (M.Data.Count == 0) return;
+
+        var headers = string.Join("\t", M.Data[0].Keys);
+        var rows = M.Data.Select(row =>
+            string.Join("\t", row.Values.Select(v => v?.ToString()?.Replace("\t", " ") ?? ""))
+        );
+
+        var fullText = string.Join("\n", new[] { headers }.Concat(rows));
+
+        await JS.InvokeVoidAsync("navigator.clipboard.writeText", fullText);
+
+        Copiado = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        Copiado = false;
+        StateHasChanged();
+    }
+
+    private async Task ExportarCsv()
+    {
+        if (M.Data.Count == 0) return;
+
+        var headers = string.Join(",", M.Data[0].Keys.Select(EscapeCsv));
+        var rows = M.Data.Select(row =>
+            string.Join(",", row.Values.Select(v => EscapeCsv(v?.ToString() ?? "")))
+        );
+
+        var csvContent = string.Join("\n", new[] { headers }.Concat(rows));
+        var bytes = System.Text.Encoding.UTF8.GetBytes(csvContent);
+        var base64 = Convert.ToBase64String(bytes);
+        var fileName = $"resultado_{DateTime.Now:yyyyMMdd_HHmmss}.csv";
+
+        await JS.InvokeVoidAsync("downloadFile", fileName, base64);
+    }
+
+    private string EscapeCsv(string input)
+    {
+        if (input.Contains('"') || input.Contains(',') || input.Contains('\n'))
+        {
+            input = input.Replace("\"", "\"\"");
+            return $"\"{input}\"";
+        }
+        return input;
+    }
+}

--- a/SAPAssistant/Models/Chat/ResultMessage.cs
+++ b/SAPAssistant/Models/Chat/ResultMessage.cs
@@ -5,6 +5,7 @@
         public string Resumen { get; set; } = string.Empty;
         public string Sql { get; set; } = string.Empty;
         public List<Dictionary<string, object>> Data { get; set; } = new();
+        public string ViewType { get; set; } = "grid";
         public override string Type => "Result";
     }
 }

--- a/SAPAssistant/Models/QueryResponse.cs
+++ b/SAPAssistant/Models/QueryResponse.cs
@@ -6,6 +6,7 @@
         public string Sql { get; set; }
         public string Resumen { get; set; }
         public string Mensaje { get; set; }
+        public string ViewType { get; set; } = "grid";
         public List<Dictionary<string, object>> Resultados { get; set; }
     }
 }

--- a/SAPAssistant/Pages/Chat/ChatAssistant.razor
+++ b/SAPAssistant/Pages/Chat/ChatAssistant.razor
@@ -136,10 +136,11 @@
                         Mensaje = resultado.Mensaje
                     },
                 _ => new ResultMessage
-                    {                        
+                    {
                         Resumen = resultado?.Resumen ?? "",
                         Sql = resultado?.Sql ?? "",
-                        Data = resultado?.Resultados ?? new()
+                        Data = resultado?.Resultados ?? new(),
+                        ViewType = resultado?.ViewType ?? "grid"
                     }
             };
 
@@ -168,10 +169,19 @@
 
     private Type GetComponentType(MessageBase msg)
     {
+        if (msg.Type == "Result")
+        {
+            var view = ((ResultMessage)msg).ViewType?.ToLower();
+            return view switch
+            {
+                "cards" => typeof(ResultCardListComponent),
+                _ => typeof(ResultGridComponent)
+            };
+        }
+
         return msg.Type switch
         {
             "Text" => typeof(TextMessageComponent),
-            "Result" => typeof(ResultMessageComponent),
             "Error" => typeof(ErrorMessageComponent),
             "system" => typeof(SystemMessageComponent),
             _ => typeof(TextMessageComponent)

--- a/SAPAssistant/Pages/Chat/DemoChat.razor
+++ b/SAPAssistant/Pages/Chat/DemoChat.razor
@@ -90,10 +90,11 @@
             else
             {
                 Messages.Add(new ResultMessage
-                    {                        
+                    {
                         Resumen = resultado?.Resumen ?? "",
                         Sql = resultado?.Sql ?? "",
-                        Data = resultado?.Resultados ?? new()
+                        Data = resultado?.Resultados ?? new(),
+                        ViewType = resultado?.ViewType ?? "grid"
                     });
             }
         }
@@ -111,15 +112,20 @@
         await JS.InvokeVoidAsync("chatEnhancer.scrollToBottom", messagesContainer);
     }
 
-    private Type GetComponentType(MessageBase msg) =>
-        msg.Type switch
-        {
-            "Text" => typeof(TextMessageComponent),
-            "Result" => typeof(ResultMessageComponent),
-            "Error" => typeof(ErrorMessageComponent),
-            "system" => typeof(SystemMessageComponent),
-            _ => typeof(TextMessageComponent)
-        };
+    private Type GetComponentType(MessageBase msg)
+        => msg.Type == "Result"
+            ? (((ResultMessage)msg).ViewType?.ToLower()) switch
+            {
+                "cards" => typeof(ResultCardListComponent),
+                _ => typeof(ResultGridComponent)
+            }
+            : msg.Type switch
+            {
+                "Text" => typeof(TextMessageComponent),
+                "Error" => typeof(ErrorMessageComponent),
+                "system" => typeof(SystemMessageComponent),
+                _ => typeof(TextMessageComponent)
+            };
 
     private Dictionary<string, object> GetParameters(MessageBase msg) =>
         new() { ["Message"] = msg };

--- a/SAPAssistant/Service/AssistantService.cs
+++ b/SAPAssistant/Service/AssistantService.cs
@@ -92,6 +92,14 @@ namespace SAPAssistant.Service
             string? resumen = null;
             string? mensaje = null;
             List<Dictionary<string, object>>? resultados = null;
+            string viewType = "grid";
+
+            if (assistantResponse.Meta != null &&
+                assistantResponse.Meta.TryGetValue("view_type", out var vtObj) &&
+                vtObj != null)
+            {
+                viewType = vtObj.ToString() ?? "grid";
+            }
 
             if (assistantResponse.Data.HasValue)
             {
@@ -128,7 +136,8 @@ namespace SAPAssistant.Service
                 Sql = sql,
                 Resumen = resumen,
                 Mensaje = mensaje,
-                Resultados = resultados
+                Resultados = resultados,
+                ViewType = viewType
             };
         }
     }


### PR DESCRIPTION
## Summary
- store result presentation mode with `ViewType` in `QueryResponse` and `ResultMessage`
- capture `view_type` metadata in `AssistantService`
- carry the new field when creating `ResultMessage`
- select `ResultGridComponent` or `ResultCardListComponent` depending on `ViewType`
- add simple implementations of the new result components

## Testing
- `dotnet build SAPAssistant/SAPAssistant.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865001079d48320a05ba5f26caf6ade