### PR TITLE
Fix duplicate resultado-panel styles

### DIFF
--- a/SAPAssistant/wwwroot/css/site.css
+++ b/SAPAssistant/wwwroot/css/site.css
@@ -230,12 +230,14 @@ textarea.auto-expand {
         color: #4ea3ff;
     }
 
+/* --- Chat/ResultGridComponent.razor.css --- */
 .resultado-panel {
     background-color: #2c2c2c;
     border-radius: 16px;
     padding: 24px;
     margin: 20px auto;
     max-width: 800px;
+    align-self: center;
     color: #e0e0e0;
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
     font-family: 'Segoe UI', 'Roboto', sans-serif;
@@ -258,6 +260,7 @@ textarea.auto-expand {
 
     .resultado-panel p {
         margin-bottom: 15px;
+        line-height: 1.5;
     }
 
     .resultado-panel pre {
@@ -811,56 +814,6 @@ body, html {
         transition: color 0.3s ease;
     }
 
-/* --- Chat/ResultGridComponent.razor.css --- */
-.resultado-panel {
-    background-color: #2b2b3c;
-    border-radius: 16px;
-    padding: 20px;
-    margin: 20px 0;
-    max-width: 800px;
-    align-self: center;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    color: #e0e0e0;
-}
-
-    .resultado-panel h3,
-    .resultado-panel h4 {
-        color: #00bfa5;
-        margin-bottom: 10px;
-    }
-
-    .resultado-panel p {
-        margin-bottom: 15px;
-        line-height: 1.5;
-    }
-
-    .resultado-panel pre {
-        background-color: #1e1e2f;
-        padding: 15px;
-        border-radius: 8px;
-        overflow-x: auto;
-        color: #00bfa5;
-        font-family: Consolas, monospace;
-        font-size: 0.95rem;
-    }
-
-    .resultado-panel table {
-        width: 100%;
-        border-collapse: collapse;
-        margin-top: 15px;
-    }
-
-    .resultado-panel th,
-    .resultado-panel td {
-        border: 1px solid #444;
-        padding: 10px;
-        text-align: left;
-    }
-
-    .resultado-panel th {
-        background-color: #333;
-        color: #00bfa5;
-    }
 
 /* --- Chat/SystemMessageComponent.razor.css --- */
 .chat-message.system-message {


### PR DESCRIPTION
## Summary
- consolidate the two `.resultado-panel` style definitions in `site.css`
- keep a single commented block for Chat/ResultGridComponent

## Testing
- `git diff --color --stat`

------
https://chatgpt.com/codex/tasks/task_e_68650941173c832094556f8a4251db0e