### PR TITLE
Add CSS for card and KPI result messages

### DIFF
--- a/SAPAssistant/Pages/_Host.cshtml
+++ b/SAPAssistant/Pages/_Host.cshtml
@@ -24,6 +24,7 @@
     <script src="js/scripts.js"></script>
     <link href="css/ConectionManager.css" rel="stylesheet" />
     <link href="css/ChatHistoryItem.css" rel="stylesheet" />
+    <link href="css/resultmessage.css" rel="stylesheet" />
 </head>
 <body>
     <component type="typeof(App)" render-mode="Server" />

--- a/SAPAssistant/wwwroot/css/resultmessage.css
+++ b/SAPAssistant/wwwroot/css/resultmessage.css
@@ -1,0 +1,33 @@
+/* Styles for ResultCardListComponent and ResultKpiComponent */
+
+.card-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.result-card {
+    background-color: #2C2C2E;
+    border-radius: 12px;
+    padding: 20px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+    color: #e0e0e0;
+}
+
+.kpi-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.kpi-item {
+    background-color: #2C2C2E;
+    border-radius: 12px;
+    padding: 16px 20px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+    color: #e0e0e0;
+    min-width: 150px;
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- style card-based results with `.card-list` and `.result-card`
- style KPI summaries with `.kpi-list` and `.kpi-item`
- include new stylesheet in the app layout

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650e5bcc7c83208b5119b9c82605ca