### PR TITLE
Add destroyChart interop for cleanup

### DIFF
--- a/SAPAssistant/Components/Dashboard/InteractiveChartComponent.razor
+++ b/SAPAssistant/Components/Dashboard/InteractiveChartComponent.razor
@@ -97,6 +97,7 @@
 
     public void Dispose()
     {
+        JS.InvokeVoidAsync("destroyChart", CanvasId);
         objRef?.Dispose();
     }
 }

--- a/SAPAssistant/wwwroot/js/chart-helper.js
+++ b/SAPAssistant/wwwroot/js/chart-helper.js
@@ -88,3 +88,14 @@ window.drawChart = (canvasId, labels, data, chartType = 'bar', dotNetHelper = nu
         }
     });
 };
+
+window.destroyChart = (canvasId) => {
+    if (window.resultCharts && window.resultCharts[canvasId]) {
+        window.resultCharts[canvasId].destroy();
+        delete window.resultCharts[canvasId];
+    }
+    if (window.miniCharts && window.miniCharts[canvasId]) {
+        window.miniCharts[canvasId].destroy();
+        delete window.miniCharts[canvasId];
+    }
+};


### PR DESCRIPTION
## Summary
- extend `chart-helper.js` with a `destroyChart` function for removing stored charts
- call `destroyChart` from `InteractiveChartComponent` disposal logic

## Testing
- `dotnet build SAPAssistant.sln -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_688342b671988320ae7b6bc4655017df