### PR TITLE
Make HttpClient base URL configurable

### DIFF
--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -12,27 +12,34 @@ using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var apiBaseUrl = builder.Configuration["ApiBaseUrl"]
+                 ?? Environment.GetEnvironmentVariable("API_BASE_URL")
+                 ?? "http://127.0.0.1:8081";
+
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor()
  .AddCircuitOptions(options => { options.DetailedErrors = true; });
-builder.Services.AddHttpClient();
+builder.Services.AddHttpClient("Default", client =>
+{
+    client.BaseAddress = new Uri(apiBaseUrl);
+});
 
 // API principal
 builder.Services.AddScoped(sp => new HttpClient
 {
-    BaseAddress = new Uri("http://127.0.0.1:8081")
+    BaseAddress = new Uri(apiBaseUrl)
 });
 
 // Servicios API específicos
 builder.Services.AddHttpClient<ConnectionService>(client =>
 {
-    client.BaseAddress = new Uri("http://127.0.0.1:8081");
+    client.BaseAddress = new Uri(apiBaseUrl);
 });
 
 builder.Services.AddHttpClient<AssistantService>(client =>
 {
-    client.BaseAddress = new Uri("http://127.0.0.1:8081");
+    client.BaseAddress = new Uri(apiBaseUrl);
 });
 
 

--- a/SAPAssistant/appsettings.Development.json
+++ b/SAPAssistant/appsettings.Development.json
@@ -5,5 +5,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "ApiBaseUrl": "http://127.0.0.1:8081"
 }

--- a/SAPAssistant/appsettings.json
+++ b/SAPAssistant/appsettings.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApiBaseUrl": "http://127.0.0.1:8081"
 }


### PR DESCRIPTION
## Summary
- allow API base URL to be configured
- update Program.cs to configure `HttpClient` instances from config

## Testing
- `dotnet build SAPAssistant/SAPAssistant.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6883437ac1c883209a3a2aed0309bed4