### PR TITLE
Add null check before getContext

### DIFF
--- a/SAPAssistant/wwwroot/js/chart-helper.js
+++ b/SAPAssistant/wwwroot/js/chart-helper.js
@@ -1,5 +1,10 @@
-﻿window.drawMiniChart = (canvasId, chartData) => {
-    const ctx = document.getElementById(canvasId).getContext('2d');
+window.drawMiniChart = (canvasId, chartData) => {
+    const canvas = document.getElementById(canvasId);
+    if (!canvas) {
+        console.error(`Canvas with id '${canvasId}' not found.`);
+        return;
+    }
+    const ctx = canvas.getContext('2d');
 
     if (window.miniCharts && window.miniCharts[canvasId]) {
         window.miniCharts[canvasId].destroy();
@@ -36,7 +41,12 @@
 };
 
 window.drawChart = (canvasId, labels, data, chartType = 'bar', dotNetHelper = null) => {
-    const ctx = document.getElementById(canvasId).getContext('2d');
+    const canvas = document.getElementById(canvasId);
+    if (!canvas) {
+        console.error(`Canvas with id '${canvasId}' not found.`);
+        return;
+    }
+    const ctx = canvas.getContext('2d');
 
     if (window.resultCharts && window.resultCharts[canvasId]) {
         window.resultCharts[canvasId].destroy();


### PR DESCRIPTION
## Summary
- guard against missing canvas element before calling `getContext`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68834469a75c8320a05257d8cc4b29d0