### PR TITLE
Add KPI catalog listing with card grid

### DIFF
--- a/SAPAssistant/Pages/Dashboard/DashboardCatalog.razor
+++ b/SAPAssistant/Pages/Dashboard/DashboardCatalog.razor
@@ -2,9 +2,9 @@
 @attribute [Authorize]
 @layout AssistantLayout
 
-@inject DashboardService DashboardService
 @inject KpiCatalogService KpiCatalogService
-@inject IJSRuntime JSRuntime
+@inject UserDashboardService UserDashboardService
+@inject DashboardService DashboardService
 
 <h1>Catálogo de KPIs</h1>
 
@@ -14,17 +14,12 @@
 }
 else
 {
-    <div class="catalog-grid">
+    <div class="dashboard-grid">
         @foreach (var card in Catalog)
         {
             <div class="catalog-card">
-                <h3>@card.Title</h3>
-                @if (card.ChartData != null && card.ChartData.Any())
-                {
-                    <canvas id="@GetCanvasId(card)" style="width:100%;height:60px;"></canvas>
-                }
-                <p>@card.Description</p>
-                <button @onclick="() => AddToDashboard(card)">Añadir a mis dashboards</button>
+                <DashboardCardWrapper Card="card" />
+                <button class="btn-add" @onclick="() => AddToDashboard(card)">Añadir a mis dashboards</button>
             </div>
         }
     </div>
@@ -60,21 +55,6 @@ else
         };
 
         DashboardService.KPIs.Add(copy);
-    }
-
-    private string GetCanvasId(DashboardCardModel card) => $"catalogChart-{card.Id}";
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            foreach (var card in Catalog)
-            {
-                if (card.ChartData != null && card.ChartData.Any())
-                {
-                    await JSRuntime.InvokeVoidAsync("drawMiniChart", GetCanvasId(card), card.ChartData);
-                }
-            }
-        }
+        await UserDashboardService.AddKpiAsync(copy);
     }
 }

--- a/SAPAssistant/Pages/Dashboard/DashboardCatalog.razor.css
+++ b/SAPAssistant/Pages/Dashboard/DashboardCatalog.razor.css
@@ -1,0 +1,25 @@
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.catalog-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.catalog-card .btn-add {
+    padding: 8px 12px;
+    border: none;
+    border-radius: 8px;
+    background-color: #3498db;
+    color: white;
+    cursor: pointer;
+}
+
+.catalog-card .btn-add:hover {
+    background-color: #2980b9;
+}

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -48,9 +48,10 @@ builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<ProtectedSessionStorage>();
 builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthStateProvider>();
 builder.Services.AddScoped<CustomAuthStateProvider>();
-builder.Services.AddScoped<DashboardService>();
-builder.Services.AddSingleton<KpiCatalogService>();
-builder.Services.AddSingleton<NotificationService>();
+    builder.Services.AddScoped<DashboardService>();
+    builder.Services.AddSingleton<KpiCatalogService>();
+    builder.Services.AddScoped<UserDashboardService>();
+    builder.Services.AddSingleton<NotificationService>();
 builder.Services.AddScoped<ChatHistoryService>();
 builder.Services.AddMudServices();
 

--- a/SAPAssistant/Service/UserDashboardService.cs
+++ b/SAPAssistant/Service/UserDashboardService.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using SAPAssistant.Models;
+using System.Net.Http.Json;
+
+namespace SAPAssistant.Service
+{
+    public class UserDashboardService
+    {
+        private readonly HttpClient _http;
+        private readonly ProtectedSessionStorage _sessionStorage;
+
+        public UserDashboardService(HttpClient http, ProtectedSessionStorage sessionStorage)
+        {
+            _http = http;
+            _sessionStorage = sessionStorage;
+        }
+
+        private async Task<string> GetUserIdAsync()
+        {
+            var userResult = await _sessionStorage.GetAsync<string>("username");
+            if (!userResult.Success)
+                throw new Exception("Usuario no encontrado en la sesión.");
+            return userResult.Value!;
+        }
+
+        public async Task AddKpiAsync(DashboardCardModel kpi)
+        {
+            var userId = await GetUserIdAsync();
+            var request = new HttpRequestMessage(HttpMethod.Post, "/user-dashboard/kpis");
+            request.Headers.Add("X-User-Id", userId);
+            request.Content = JsonContent.Create(kpi);
+
+            var response = await _http.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var error = await response.Content.ReadAsStringAsync();
+                throw new Exception($"Error al agregar KPI: {response.StatusCode} - {error}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show KPI catalog using same card structure as dashboard
- allow users to add catalog KPIs via new `UserDashboardService.AddKpiAsync`
- register `UserDashboardService` in the app
- style catalog grid with dedicated CSS

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688363fa8268832091e6f5dc97b2e1e9