### PR TITLE
refactor: move chat logic to viewmodel

### DIFF
--- a/SAPAssistant/Pages/Chat/ChatAssistant.razor
+++ b/SAPAssistant/Pages/Chat/ChatAssistant.razor
@@ -1,28 +1,23 @@
-﻿@page "/"
+@page "/"
 @page "/chat/{chatId}"
 @layout ChatLayout
 @using Microsoft.AspNetCore.Components.Web
 @using SAPAssistant.Components.Chat
 @using SAPAssistant.Models.Chat
-@using SAPAssistant.Service
-@using SAPAssistant.Models
-@using System.Text.Json
-@inject IJSRuntime JS
-@inject AssistantService AssistantService
-@inject ChatHistoryService ChatHistoryService
-
+@using SAPAssistant.ViewModels
+@inject ChatViewModel VM
 
 <div class="chat-content-full">
-    <div class="messages" @ref="messagesContainer">
-        @foreach (var msg in Messages)
+    <div class="messages" @ref="VM.MessagesContainer">
+        @foreach (var msg in VM.Messages)
         {
-            <DynamicComponent Type="@GetComponentType(msg)" Parameters="GetParameters(msg)" />
+            <DynamicComponent Type="@VM.GetComponentType(msg)" Parameters="VM.GetParameters(this, msg)" />
         }
     </div>
 
     <div class="input-area">
-        <SearchBar @bind-SearchText="UserInput" OnSearch="SendMessage" Disabled="isProcessing" />
-        @if (isProcessing)
+        <SearchBar @bind-SearchText="VM.UserInput" OnSearch="VM.SendMessage" Disabled="VM.IsProcessing" />
+        @if (VM.IsProcessing)
         {
             <div class="loading-spinner">⌛ Procesando...</div>
         }
@@ -30,200 +25,10 @@
 </div>
 
 @code {
-
-    private bool isProcessing = false;
-    private string? preferredViewType;
-    private ElementReference messagesContainer;
-    private ChatSession? CurrentSession { get; set; }
-    private string UserInput { get; set; } = string.Empty;
-    private List<MessageBase> Messages { get; set; } = new();
-
     [Parameter]
     public string? chatId { get; set; }
 
-    protected override async Task OnInitializedAsync()
-    {
-        preferredViewType = await JS.InvokeAsync<string>("viewTypePref.get");
-    }
+    protected override async Task OnInitializedAsync() => await VM.OnInitializedAsync();
 
-
-    protected override async Task OnParametersSetAsync()
-    {
-        var options = new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true
-            };
-
-        Messages.Clear(); // Limpiar mensajes anteriores
-
-        if (!string.IsNullOrWhiteSpace(chatId))
-        {
-            CurrentSession = await ChatHistoryService.GetChatSessionAsync(chatId);
-        }
-        else
-        {
-            CurrentSession = new ChatSession
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    Fecha = DateTime.Now,
-                    Titulo = "Nuevo chat"
-                };
-        }
-
-        if (CurrentSession?.MensajesRaw != null)
-        {
-            foreach (var msgRaw in CurrentSession.MensajesRaw)
-            {
-                try
-                {
-                    var json = JsonSerializer.Serialize(msgRaw);
-                    var response = JsonSerializer.Deserialize<AssistantResponse>(json, options);
-                    var tipo = msgRaw.TryGetValue("tipo", out var typeObj)
-                               ? typeObj?.ToString()?.ToLower()
-                               : null;
-
-                    if (tipo == null) continue;
-
-                    MessageBase? msg = tipo switch
-                    {
-                        "text" => JsonSerializer.Deserialize<TextMessage>(json, options),
-                        "aclaracion" => JsonSerializer.Deserialize<TextMessage>(json, options),
-                        "assistant" => JsonSerializer.Deserialize<TextMessage>(json, options),
-                        "result" => JsonSerializer.Deserialize<ResultMessage>(json, options),
-                        "error" => JsonSerializer.Deserialize<ErrorMessage>(json, options),
-                        "system" => JsonSerializer.Deserialize<SystemMessage>(json, options),
-                        "consulta" => JsonSerializer.Deserialize<ResultMessage>(json, options),
-                        _ => null
-                    };
-
-                    if (msg != null)
-                    {
-                        if (msg is ResultMessage rm && !string.IsNullOrEmpty(preferredViewType))
-                        {
-                            rm.ViewType = preferredViewType;
-                        }
-                        Messages.Add(msg);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.Error.WriteLine($"Error al deserializar mensaje: {ex.Message}");
-                }
-            }
-        }
-
-    }
-
-
-
-    private async Task SendMessage(string message)
-    {
-        if (string.IsNullOrWhiteSpace(message) || isProcessing) return;
-
-        isProcessing = true;
-
-        var userMsg = new TextMessage
-            {
-                Mensaje = message,
-                Role = "user"
-            };
-
-        Messages.Add(userMsg);
-
-        try
-        {
-            var resultado = await AssistantService.ConsultarAsync(message, CurrentSession!.Id);
-
-            MessageBase responseMsg = resultado?.Tipo switch
-            {
-                "aclaracion" or "assistant" => new TextMessage
-                    {
-                        Role = "assistant",
-                        Mensaje = resultado.Mensaje
-                    },
-                "resumen" => new TextMessage
-                    {                        
-                        Mensaje = resultado.Resumen
-                    },
-                "system" => new SystemMessage
-                    {
-                        Mensaje = resultado.Mensaje
-                    },
-                _ => new ResultMessage
-                    {
-                        Resumen = resultado?.Resumen ?? "",
-                        Sql = resultado?.Sql ?? "",
-                        Data = resultado?.Resultados ?? new(),
-                        ViewType = preferredViewType ?? resultado?.ViewType ?? "grid"
-                    }
-            };
-
-            Messages.Add(responseMsg);
-        }
-        catch (Exception ex)
-        {
-            Messages.Add(new ErrorMessage
-                {                    
-                    Mensaje = ex.Message
-                });
-        }
-
-        // 🧠 Actualizar y guardar sesión
-        // CurrentSession!.Mensajes = Messages;
-        // await ChatHistoryService.SaveChatSessionAsync(CurrentSession, Messages);
-
-        isProcessing = false;
-        await ScrollToBottom();
-    }
-
-    private async Task ScrollToBottom()
-    {
-        await JS.InvokeVoidAsync("chatEnhancer.scrollToBottom", messagesContainer);
-    }
-
-    private Type GetComponentType(MessageBase msg)
-    {
-        if (msg.Type == "Result")
-        {
-            var view = ((ResultMessage)msg).ViewType?.ToLower();
-            return view switch
-            {
-                "cards" => typeof(ResultCardListComponent),
-                "kpi" => typeof(ResultKpiComponent),
-                "chart" => typeof(ResultChartComponent),
-                _ => typeof(ResultGridComponent)
-            };
-        }
-
-        return msg.Type switch
-        {
-            "Text" => typeof(TextMessageComponent),
-            "Error" => typeof(ErrorMessageComponent),
-            "system" => typeof(SystemMessageComponent),
-            _ => typeof(TextMessageComponent)
-        };
-    }
-
-    private Dictionary<string, object> GetParameters(MessageBase msg)
-    {
-        var parameters = new Dictionary<string, object>
-        {
-            ["Message"] = msg
-        };
-
-        if (msg is ResultMessage)
-        {
-            parameters["OnViewTypeChange"] = EventCallback.Factory.Create<string>(this, (string vt) => OnViewTypeChanged((ResultMessage)msg, vt));
-        }
-
-        return parameters;
-    }
-
-    private async Task OnViewTypeChanged(ResultMessage msg, string viewType)
-    {
-        msg.ViewType = viewType;
-        preferredViewType = viewType;
-        await JS.InvokeVoidAsync("viewTypePref.set", viewType);
-        StateHasChanged();
-    }
+    protected override async Task OnParametersSetAsync() => await VM.OnParametersSetAsync(chatId);
 }

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -9,6 +9,7 @@ using SAPAssistant.Security.Policies;
 using Microsoft.AspNetCore.Authorization;
 using SAPAssistant.Exceptions;
 using MudBlazor.Services;
+using SAPAssistant.ViewModels;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -54,6 +55,7 @@ builder.Services.AddScoped<CustomAuthStateProvider>();
     builder.Services.AddSingleton<NotificationService>();
 builder.Services.AddScoped<ChatHistoryService>();
 builder.Services.AddMudServices();
+builder.Services.AddScoped<ChatViewModel>();
 
 
 // ✅ Política de conexión activa

--- a/SAPAssistant/SAPAssistant.csproj
+++ b/SAPAssistant/SAPAssistant.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="MudBlazor" Version="8.9.0" />
   </ItemGroup>
 

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -1,0 +1,215 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+using SAPAssistant.Components.Chat;
+using SAPAssistant.Models;
+using SAPAssistant.Models.Chat;
+using SAPAssistant.Service;
+using System.Text.Json;
+
+namespace SAPAssistant.ViewModels;
+
+public partial class ChatViewModel : ObservableObject
+{
+    private readonly IJSRuntime _js;
+    private readonly AssistantService _assistantService;
+    private readonly ChatHistoryService _chatHistoryService;
+
+    public ElementReference MessagesContainer { get; set; }
+
+    private string? preferredViewType;
+    private ChatSession? CurrentSession { get; set; }
+
+    [ObservableProperty]
+    private List<MessageBase> messages = new();
+
+    [ObservableProperty]
+    private string userInput = string.Empty;
+
+    [ObservableProperty]
+    private bool isProcessing;
+
+    public ChatViewModel(IJSRuntime js, AssistantService assistantService, ChatHistoryService chatHistoryService)
+    {
+        _js = js;
+        _assistantService = assistantService;
+        _chatHistoryService = chatHistoryService;
+    }
+
+    public async Task OnInitializedAsync()
+    {
+        preferredViewType = await _js.InvokeAsync<string>("viewTypePref.get");
+    }
+
+    public async Task OnParametersSetAsync(string? chatId)
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        Messages.Clear();
+
+        if (!string.IsNullOrWhiteSpace(chatId))
+        {
+            CurrentSession = await _chatHistoryService.GetChatSessionAsync(chatId);
+        }
+        else
+        {
+            CurrentSession = new ChatSession
+            {
+                Id = Guid.NewGuid().ToString(),
+                Fecha = DateTime.Now,
+                Titulo = "Nuevo chat"
+            };
+        }
+
+        if (CurrentSession?.MensajesRaw != null)
+        {
+            foreach (var msgRaw in CurrentSession.MensajesRaw)
+            {
+                try
+                {
+                    var json = JsonSerializer.Serialize(msgRaw);
+                    var tipo = msgRaw.TryGetValue("tipo", out var typeObj)
+                               ? typeObj?.ToString()?.ToLower()
+                               : null;
+
+                    if (tipo == null) continue;
+
+                    MessageBase? msg = tipo switch
+                    {
+                        "text" => JsonSerializer.Deserialize<TextMessage>(json, options),
+                        "aclaracion" => JsonSerializer.Deserialize<TextMessage>(json, options),
+                        "assistant" => JsonSerializer.Deserialize<TextMessage>(json, options),
+                        "result" => JsonSerializer.Deserialize<ResultMessage>(json, options),
+                        "error" => JsonSerializer.Deserialize<ErrorMessage>(json, options),
+                        "system" => JsonSerializer.Deserialize<SystemMessage>(json, options),
+                        "consulta" => JsonSerializer.Deserialize<ResultMessage>(json, options),
+                        _ => null
+                    };
+
+                    if (msg != null)
+                    {
+                        if (msg is ResultMessage rm && !string.IsNullOrEmpty(preferredViewType))
+                        {
+                            rm.ViewType = preferredViewType;
+                        }
+                        Messages.Add(msg);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Error al deserializar mensaje: {ex.Message}");
+                }
+            }
+        }
+    }
+
+    public async Task SendMessage(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message) || IsProcessing) return;
+
+        IsProcessing = true;
+
+        var userMsg = new TextMessage
+        {
+            Mensaje = message,
+            Role = "user"
+        };
+
+        Messages.Add(userMsg);
+
+        try
+        {
+            var resultado = await _assistantService.ConsultarAsync(message, CurrentSession!.Id);
+
+            MessageBase responseMsg = resultado?.Tipo switch
+            {
+                "aclaracion" or "assistant" => new TextMessage
+                {
+                    Role = "assistant",
+                    Mensaje = resultado.Mensaje
+                },
+                "resumen" => new TextMessage
+                {
+                    Mensaje = resultado.Resumen
+                },
+                "system" => new SystemMessage
+                {
+                    Mensaje = resultado.Mensaje
+                },
+                _ => new ResultMessage
+                {
+                    Resumen = resultado?.Resumen ?? "",
+                    Sql = resultado?.Sql ?? "",
+                    Data = resultado?.Resultados ?? new(),
+                    ViewType = preferredViewType ?? resultado?.ViewType ?? "grid"
+                }
+            };
+
+            Messages.Add(responseMsg);
+        }
+        catch (Exception ex)
+        {
+            Messages.Add(new ErrorMessage
+            {
+                Mensaje = ex.Message
+            });
+        }
+
+        IsProcessing = false;
+        await ScrollToBottom();
+    }
+
+    public async Task ScrollToBottom()
+    {
+        await _js.InvokeVoidAsync("chatEnhancer.scrollToBottom", MessagesContainer);
+    }
+
+    public Type GetComponentType(MessageBase msg)
+    {
+        if (msg.Type == "Result")
+        {
+            var view = ((ResultMessage)msg).ViewType?.ToLower();
+            return view switch
+            {
+                "cards" => typeof(ResultCardListComponent),
+                "kpi" => typeof(ResultKpiComponent),
+                "chart" => typeof(ResultChartComponent),
+                _ => typeof(ResultGridComponent)
+            };
+        }
+
+        return msg.Type switch
+        {
+            "Text" => typeof(TextMessageComponent),
+            "Error" => typeof(ErrorMessageComponent),
+            "system" => typeof(SystemMessageComponent),
+            _ => typeof(TextMessageComponent)
+        };
+    }
+
+    public Dictionary<string, object> GetParameters(ComponentBase component, MessageBase msg)
+    {
+        var parameters = new Dictionary<string, object>
+        {
+            ["Message"] = msg
+        };
+
+        if (msg is ResultMessage)
+        {
+            parameters["OnViewTypeChange"] = EventCallback.Factory.Create<string>(component, (string vt) => OnViewTypeChanged((ResultMessage)msg, vt));
+        }
+
+        return parameters;
+    }
+
+    public async Task OnViewTypeChanged(ResultMessage msg, string viewType)
+    {
+        msg.ViewType = viewType;
+        preferredViewType = viewType;
+        await _js.InvokeVoidAsync("viewTypePref.set", viewType);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ChatViewModel to encapsulate chat state and operations
- register ChatViewModel as scoped service
- inject ChatViewModel into ChatAssistant page

## Testing
- `dotnet build SAPAssistant/SAPAssistant.csproj`

------
https://chatgpt.com/codex/tasks/task_e_688cfd5852888320b5a2ba64fa89f814