### PR TITLE
Add DashboardPage ViewModel and integrate into dashboard page

### DIFF
--- a/SAPAssistant/Pages/Dashboard/DashboardPage.razor
+++ b/SAPAssistant/Pages/Dashboard/DashboardPage.razor
@@ -1,33 +1,34 @@
 ﻿@page "/dashboard"
 @using SAPAssistant.Service
 @using SAPAssistant.Models
+@using SAPAssistant.ViewModels
 @attribute [Authorize]
 @layout AssistantLayout
 
-@inject DashboardService DashboardService
+@inject DashboardPageViewModel VM
 
 <h1>📊 Mi Cockpit Inteligente</h1>
 
 <div class="dashboard-actions">
-    <button class="btn-global-refresh" @onclick="RefreshAll">🔄 Actualizar Todo</button>
-    <button class="btn-create-kpi" @onclick="OpenWizard">✨ Crear Nuevo KPI</button>
-    <button class="btn-edit-dashboard" @onclick="EditDashboard">🛠️ Editar Dashboard</button>
+    <button class="btn-global-refresh" @onclick="VM.RefreshAll">🔄 Actualizar Todo</button>
+    <button class="btn-create-kpi" @onclick="VM.OpenWizard">✨ Crear Nuevo KPI</button>
+    <button class="btn-edit-dashboard" @onclick="VM.EditDashboard">🛠️ Editar Dashboard</button>
 </div>
 
-@if (IsWizardOpen)
+@if (VM.IsWizardOpen)
 {
-    <DashboardWizard OnFinished="CloseWizard" />
+    <DashboardWizard OnFinished="VM.CloseWizard" />
 }
 else
 {
-    @if (DashboardService.KPIs.Count == 0)
+    @if (VM.DashboardService.KPIs.Count == 0)
     {
-        <DashboardEmptyState OnCreateKPI="OpenWizard" />
+        <DashboardEmptyState OnCreateKPI="VM.OpenWizard" />
     }
     else
     {
         <div class="dashboard-grid">
-            @foreach (var card in DashboardService.KPIs)
+            @foreach (var card in VM.DashboardService.KPIs)
             {
                 <DashboardCardWrapper Card="card" />
             }
@@ -35,27 +36,3 @@ else
     }
 }
 
-@code {
-    private bool IsWizardOpen = false;
-
-    private void OpenWizard()
-    {
-        IsWizardOpen = true;
-    }
-
-    private void CloseWizard()
-    {
-        IsWizardOpen = false;
-        StateHasChanged();
-    }
-
-    private void EditDashboard()
-    {
-        // Aquí podrías activar modo edición en el futuro
-    }
-
-    private async Task RefreshAll()
-    {
-        await DashboardService.RefreshAllKPIs();
-    }
-}

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddScoped<HomeViewModel>();
 builder.Services.AddScoped<LoginViewModel>();
 builder.Services.AddScoped<ConnectionSettingsViewModel>();
 builder.Services.AddScoped<ConnectionSelectionViewModel>();
+builder.Services.AddScoped<DashboardPageViewModel>();
 
 
 // ✅ Política de conexión activa

--- a/SAPAssistant/ViewModels/DashboardPageViewModel.cs
+++ b/SAPAssistant/ViewModels/DashboardPageViewModel.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using SAPAssistant.Service;
+
+namespace SAPAssistant.ViewModels;
+
+public partial class DashboardPageViewModel : BaseViewModel
+{
+    public DashboardService DashboardService { get; }
+
+    [ObservableProperty]
+    private bool isWizardOpen;
+
+    public DashboardPageViewModel(DashboardService dashboardService)
+    {
+        DashboardService = dashboardService;
+    }
+
+    public void OpenWizard() => IsWizardOpen = true;
+
+    public void CloseWizard() => IsWizardOpen = false;
+
+    public void EditDashboard()
+    {
+        // Modo edición del dashboard se implementará en el futuro
+    }
+
+    public async Task RefreshAll()
+    {
+        await DashboardService.RefreshAllKPIs();
+    }
+}


### PR DESCRIPTION
## Summary
- add DashboardPageViewModel with wizard state and dashboard interactions
- inject DashboardPageViewModel into DashboardPage and use its methods
- register DashboardPageViewModel in the DI container

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688d2846937c83209759e1bea7114111