### PR TITLE
feat: extract dashboard wizard view model

### DIFF
--- a/SAPAssistant/Pages/Dashboard/DashboardWizard.razor
+++ b/SAPAssistant/Pages/Dashboard/DashboardWizard.razor
@@ -1,12 +1,12 @@
-﻿@using SAPAssistant.Service
-@inject DashboardService DashboardService
+@using SAPAssistant.ViewModels
+@inject DashboardWizardViewModel VM
 
 <div class="dashboard-wizard">
     <h2>✨ Crea tu nuevo KPI</h2>
 
-    <EditForm Model="NewKpiModel" OnValidSubmit="CreateKPI">
-        <InputText @bind-Value="NewKpiModel.Prompt" placeholder="¿Qué quieres consultar?" class="input-prompt" />
-        <select @bind="NewKpiModel.ChartType" class="select-chart-type">
+    <EditForm Model="VM.NewKpiModel" OnValidSubmit="VM.CreateKPI">
+        <InputText @bind-Value="VM.NewKpiModel.Prompt" placeholder="¿Qué quieres consultar?" class="input-prompt" />
+        <select @bind="VM.NewKpiModel.ChartType" class="select-chart-type">
             <option value="bar">📊 Gráfico de Barras</option>
             <option value="pie">🥧 Gráfico de Pastel</option>
             <option value="number">🔢 Número</option>
@@ -14,29 +14,15 @@
         <button type="submit" class="btn-submit">Agregar al Dashboard</button>
     </EditForm>
 
-    <button class="btn-cancel" @onclick="Cancel">Cancelar</button>
+    <button class="btn-cancel" @onclick="VM.Cancel">Cancelar</button>
 </div>
 
 @code {
     [Parameter]
     public EventCallback OnFinished { get; set; }
 
-    private NewKpiInputModel NewKpiModel = new();
-
-    private async Task CreateKPI()
+    protected override void OnParametersSet()
     {
-        await DashboardService.CreateNewKPI(NewKpiModel.Prompt,NewKpiModel.ChartType);
-        await OnFinished.InvokeAsync();
-    }
-
-    private async Task Cancel()
-    {
-        await OnFinished.InvokeAsync();
-    }
-
-    private class NewKpiInputModel
-    {
-        public string Prompt { get; set; } = "";
-        public string ChartType { get; set; } = "bar";
+        VM.OnFinished = OnFinished;
     }
 }

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddScoped<ConnectionSettingsViewModel>();
 builder.Services.AddScoped<ConnectionSelectionViewModel>();
 builder.Services.AddScoped<DashboardPageViewModel>();
 builder.Services.AddScoped<DashboardCatalogViewModel>();
+builder.Services.AddScoped<DashboardWizardViewModel>();
 
 
 // ✅ Política de conexión activa

--- a/SAPAssistant/ViewModels/DashboardWizardViewModel.cs
+++ b/SAPAssistant/ViewModels/DashboardWizardViewModel.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Components;
+using CommunityToolkit.Mvvm.ComponentModel;
+using SAPAssistant.Service;
+
+namespace SAPAssistant.ViewModels;
+
+public partial class DashboardWizardViewModel : BaseViewModel
+{
+    private readonly DashboardService _dashboardService;
+
+    [ObservableProperty]
+    private NewKpiModel newKpiModel = new();
+
+    public EventCallback OnFinished { get; set; }
+
+    public DashboardWizardViewModel(DashboardService dashboardService)
+    {
+        _dashboardService = dashboardService;
+    }
+
+    public async Task CreateKPI()
+    {
+        await _dashboardService.CreateNewKPI(NewKpiModel.Prompt, NewKpiModel.ChartType);
+        if (OnFinished.HasDelegate)
+        {
+            await OnFinished.InvokeAsync();
+        }
+    }
+
+    public async Task Cancel()
+    {
+        if (OnFinished.HasDelegate)
+        {
+            await OnFinished.InvokeAsync();
+        }
+    }
+}
+
+public class NewKpiModel
+{
+    public string Prompt { get; set; } = "";
+    public string ChartType { get; set; } = "bar";
+}


### PR DESCRIPTION
## Summary
- add DashboardWizardViewModel with KPI creation and cancellation flow
- inject and register the new view model in DashboardWizard component and program startup
- delegate form logic from DashboardWizard.razor to the view model

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688d2e37b6988320a865578d0a43b3a7