### PR TITLE
feat: centralize session context lookups

### DIFF
--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -47,6 +47,7 @@ builder.Services.AddHttpClient<AssistantService>(client =>
 builder.Services.AddSingleton<WeatherForecastService>();
 builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<ProtectedSessionStorage>();
+builder.Services.AddScoped<SessionContextService>();
 builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthStateProvider>();
 builder.Services.AddScoped<CustomAuthStateProvider>();
     builder.Services.AddScoped<DashboardService>();

--- a/SAPAssistant/Service/SessionContextService.cs
+++ b/SAPAssistant/Service/SessionContextService.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+namespace SAPAssistant.Service
+{
+    public class SessionContextService
+    {
+        private readonly ProtectedSessionStorage _sessionStorage;
+
+        public SessionContextService(ProtectedSessionStorage sessionStorage)
+        {
+            _sessionStorage = sessionStorage;
+        }
+
+        public async Task<string?> GetUserIdAsync()
+        {
+            var result = await _sessionStorage.GetAsync<string>("username");
+            return result.Success ? result.Value : null;
+        }
+
+        public async Task<string?> GetTokenAsync()
+        {
+            var result = await _sessionStorage.GetAsync<string>("token");
+            return result.Success ? result.Value : null;
+        }
+
+        public async Task<string?> GetRemoteIpAsync()
+        {
+            var result = await _sessionStorage.GetAsync<string>("remote_url");
+            return result.Success ? result.Value?.TrimEnd('/') : null;
+        }
+
+        public async Task<string?> GetActiveConnectionIdAsync()
+        {
+            var result = await _sessionStorage.GetAsync<string>("active_connection_id");
+            return result.Success ? result.Value : null;
+        }
+
+        public async Task<string?> GetDatabaseTypeAsync()
+        {
+            var result = await _sessionStorage.GetAsync<string>("active_db_type");
+            return result.Success ? result.Value : null;
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SessionContextService to encapsulate session storage access
- refactor AssistantService, ConnectionService and UserDashboardService to use SessionContextService
- register SessionContextService in DI container

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688d40b513208320ae28bc0ef8968c7b