### PR TITLE
Refactor StateContainer to ObservableObject

### DIFF
--- a/SAPAssistant/Pages/Chat/ChatAssistant.razor
+++ b/SAPAssistant/Pages/Chat/ChatAssistant.razor
@@ -6,8 +6,10 @@
 @using SAPAssistant.Models.Chat
 @using SAPAssistant.ViewModels
 @using SAPAssistant.Service
+@using System.ComponentModel
 @inject ChatViewModel VM
 @inject StateContainer State
+@implements IDisposable
 
 <div class="chat-content-full">
     <div class="messages" @ref="VM.MessagesContainer">
@@ -30,7 +32,16 @@
     [Parameter]
     public string? chatId { get; set; }
 
-    protected override async Task OnInitializedAsync() => await VM.OnInitializedAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        State.PropertyChanged += HandleStateChanged;
+        await VM.OnInitializedAsync();
+    }
 
     protected override async Task OnParametersSetAsync() => await VM.OnParametersSetAsync(chatId);
+
+    private void HandleStateChanged(object? sender, PropertyChangedEventArgs e)
+        => InvokeAsync(StateHasChanged);
+
+    public void Dispose() => State.PropertyChanged -= HandleStateChanged;
 }

--- a/SAPAssistant/Pages/Login.razor
+++ b/SAPAssistant/Pages/Login.razor
@@ -1,10 +1,12 @@
 @page "/login"
 @using SAPAssistant.ViewModels
 @using SAPAssistant.Service
+@using System.ComponentModel
 @attribute [AllowAnonymous]
 @layout PublicLayout
 @inject LoginViewModel VM
 @inject StateContainer State
+@implements IDisposable
 
 <div class="flex-center">
     <div class="card">
@@ -73,5 +75,17 @@
             <circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="5"></circle>
         </svg>
     </div>
+}
+
+@code {
+    protected override void OnInitialized()
+    {
+        State.PropertyChanged += HandleStateChanged;
+    }
+
+    private void HandleStateChanged(object? sender, PropertyChangedEventArgs e)
+        => InvokeAsync(StateHasChanged);
+
+    public void Dispose() => State.PropertyChanged -= HandleStateChanged;
 }
 

--- a/SAPAssistant/Service/StateContainer.cs
+++ b/SAPAssistant/Service/StateContainer.cs
@@ -1,4 +1,4 @@
-using System;
+using CommunityToolkit.Mvvm.ComponentModel;
 using SAPAssistant.Models;
 
 namespace SAPAssistant.Service
@@ -6,32 +6,15 @@ namespace SAPAssistant.Service
     /// <summary>
     /// Contenedor de estado compartido entre componentes y servicios.
     /// </summary>
-    public class StateContainer
+    public partial class StateContainer : ObservableObject
     {
-        public LoginResponse? AuthenticatedUser { get; private set; }
-        public ConnectionDTO? ActiveConnection { get; private set; }
-        public ChatSession? CurrentChat { get; private set; }
+        [ObservableProperty]
+        private LoginResponse? authenticatedUser;
 
-        public event Action? OnChange;
+        [ObservableProperty]
+        private ConnectionDTO? activeConnection;
 
-        public void SetUser(LoginResponse? user)
-        {
-            AuthenticatedUser = user;
-            NotifyStateChanged();
-        }
-
-        public void SetConnection(ConnectionDTO? connection)
-        {
-            ActiveConnection = connection;
-            NotifyStateChanged();
-        }
-
-        public void SetChat(ChatSession? chat)
-        {
-            CurrentChat = chat;
-            NotifyStateChanged();
-        }
-
-        private void NotifyStateChanged() => OnChange?.Invoke();
+        [ObservableProperty]
+        private ChatSession? currentChat;
     }
 }

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -107,7 +107,7 @@ public partial class ChatViewModel : BaseViewModel
             }
         }
 
-        _stateContainer.SetChat(CurrentSession);
+        _stateContainer.CurrentChat = CurrentSession;
     }
 
     public async Task SendMessage(string message)

--- a/SAPAssistant/ViewModels/LoginViewModel.cs
+++ b/SAPAssistant/ViewModels/LoginViewModel.cs
@@ -57,7 +57,7 @@ public partial class LoginViewModel : BaseViewModel
 
             if (result.Success)
             {
-                _stateContainer.SetUser(result.Data);
+                _stateContainer.AuthenticatedUser = result.Data;
                 _navigation.NavigateTo("/");
             }
             else


### PR DESCRIPTION
## Summary
- Refactor StateContainer to inherit from ObservableObject and use `[ObservableProperty]` for shared state
- Replace custom notification methods with automatic property change notifications
- Update view models and pages to set and react to property changes

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688d4e2f4b548320800b78391f1731a5