### PR TITLE
Use ObservableObject for shared state

### DIFF
--- a/SAPAssistant/Pages/Chat/ChatAssistant.razor
+++ b/SAPAssistant/Pages/Chat/ChatAssistant.razor
@@ -41,7 +41,12 @@
     protected override async Task OnParametersSetAsync() => await VM.OnParametersSetAsync(chatId);
 
     private void HandleStateChanged(object? sender, PropertyChangedEventArgs e)
-        => InvokeAsync(StateHasChanged);
+    {
+        if (e.PropertyName == nameof(State.CurrentChat))
+        {
+            InvokeAsync(StateHasChanged);
+        }
+    }
 
     public void Dispose() => State.PropertyChanged -= HandleStateChanged;
 }

--- a/SAPAssistant/Pages/Login.razor
+++ b/SAPAssistant/Pages/Login.razor
@@ -84,7 +84,12 @@
     }
 
     private void HandleStateChanged(object? sender, PropertyChangedEventArgs e)
-        => InvokeAsync(StateHasChanged);
+    {
+        if (e.PropertyName == nameof(State.AuthenticatedUser))
+        {
+            InvokeAsync(StateHasChanged);
+        }
+    }
 
     public void Dispose() => State.PropertyChanged -= HandleStateChanged;
 }

--- a/SAPAssistant/Service/StateContainer.cs
+++ b/SAPAssistant/Service/StateContainer.cs
@@ -8,12 +8,21 @@ namespace SAPAssistant.Service
     /// </summary>
     public partial class StateContainer : ObservableObject
     {
+        /// <summary>
+        /// Usuario autenticado actual.
+        /// </summary>
         [ObservableProperty]
         private LoginResponse? authenticatedUser;
 
+        /// <summary>
+        /// Conexión activa seleccionada.
+        /// </summary>
         [ObservableProperty]
         private ConnectionDTO? activeConnection;
 
+        /// <summary>
+        /// Sesión de chat en curso.
+        /// </summary>
         [ObservableProperty]
         private ChatSession? currentChat;
     }


### PR DESCRIPTION
## Summary
- Document StateContainer properties and leverage CommunityToolkit's ObservableObject
- React to StateContainer changes via PropertyChanged in login and chat pages

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688dad61a13c832097e85d1622030c1a