### PR TITLE
Refactor ChatHistoryService with interface and context injection

### DIFF
--- a/SAPAssistant/Components/Chat/ChatHistory.razor
+++ b/SAPAssistant/Components/Chat/ChatHistory.razor
@@ -1,6 +1,6 @@
 ﻿@using SAPAssistant.Models
-@using SAPAssistant.Service
-@inject ChatHistoryService ChatService
+@using SAPAssistant.Service.Interfaces
+@inject IChatHistoryService ChatService
 @inject NavigationManager Navigation
 
 <div class="sidebar">

--- a/SAPAssistant/Exceptions/ChatHistoryServiceException.cs
+++ b/SAPAssistant/Exceptions/ChatHistoryServiceException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace SAPAssistant.Exceptions
+{
+    public class ChatHistoryServiceException : Exception
+    {
+        public ChatHistoryServiceException() { }
+        public ChatHistoryServiceException(string message) : base(message) { }
+        public ChatHistoryServiceException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddScoped<CustomAuthStateProvider>();
     builder.Services.AddSingleton<KpiCatalogService>();
     builder.Services.AddScoped<IUserDashboardService, UserDashboardService>();
 builder.Services.AddSingleton<NotificationService>();
-builder.Services.AddScoped<ChatHistoryService>();
+builder.Services.AddScoped<IChatHistoryService, ChatHistoryService>();
 builder.Services.AddMudServices();
 
 builder.Services.AddScoped<StateContainer>();

--- a/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
+++ b/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
@@ -1,0 +1,14 @@
+using SAPAssistant.Models;
+using SAPAssistant.Models.Chat;
+
+namespace SAPAssistant.Service.Interfaces
+{
+    public interface IChatHistoryService
+    {
+        Task<List<ChatSession>> GetChatHistoryAsync();
+        Task<ChatSession?> GetChatSessionAsync(string chatId);
+        Task SaveChatSessionAsync(ChatSession session, List<MessageBase> mensajes);
+        Task DeleteChatSessionAsync(string chatId);
+        Task<ChatSession?> GetLastChatSessionAsync();
+    }
+}

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -14,7 +14,7 @@ public partial class ChatViewModel : BaseViewModel
 {
     private readonly IJSRuntime _js;
     private readonly IAssistantService _assistantService;
-    private readonly ChatHistoryService _chatHistoryService;
+    private readonly IChatHistoryService _chatHistoryService;
     private readonly StateContainer _stateContainer;
 
     public ElementReference MessagesContainer { get; set; }
@@ -31,7 +31,7 @@ public partial class ChatViewModel : BaseViewModel
     [ObservableProperty]
     private bool isProcessing;
 
-    public ChatViewModel(IJSRuntime js, IAssistantService assistantService, ChatHistoryService chatHistoryService, StateContainer stateContainer)
+    public ChatViewModel(IJSRuntime js, IAssistantService assistantService, IChatHistoryService chatHistoryService, StateContainer stateContainer)
     {
         _js = js;
         _assistantService = assistantService;


### PR DESCRIPTION
## Summary
- add IChatHistoryService to define chat history operations
- use SessionContextService and ILogger in ChatHistoryService and throw ChatHistoryServiceException
- update components and view model to depend on IChatHistoryService

## Testing
- `~/.dotnet/dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688dadb45d148320817b772722a315bc