### PR TITLE
Refactor chat history to ViewModel

### DIFF
--- a/SAPAssistant/Components/Chat/ChatHistory.razor
+++ b/SAPAssistant/Components/Chat/ChatHistory.razor
@@ -1,80 +1,32 @@
 ﻿@using SAPAssistant.Models
-@using SAPAssistant.Service.Interfaces
-@using SAPAssistant.Service
-@inject IChatHistoryService ChatService
-@inject NavigationManager Navigation
-@inject NotificationService NotificationService
+@using SAPAssistant.ViewModels
+@inject ChatHistoryViewModel VM
 
 <div class="sidebar">
-    <button class="btn btn-primary w-100 mb-3" @onclick="StartNewChat">+ Nuevo Chat</button>
+    <button class="btn btn-primary w-100 mb-3" @onclick="VM.StartNewChat">+ Nuevo Chat</button>
 
-    @if (Sessions == null)
+    @if (VM.IsLoading)
     {
         <p>Cargando historial...</p>
     }
-    else if (!Sessions.Any())
+    else if (!VM.Sessions.Any())
     {
         <p>No hay chats guardados.</p>
     }
     else
     {
-        @foreach (var chat in Sessions.OrderByDescending(c => c.Fecha))
+        @foreach (var chat in VM.Sessions.OrderByDescending(c => c.Fecha))
         {
             <ChatHistoryItem Chat="chat"
-                             OnOpenChat="OpenChat"
-                             OnDeleteChat="DeleteChat" />
+                             OnOpenChat="VM.OpenChat"
+                             OnDeleteChat="VM.DeleteChat" />
         }
     }
 </div>
 
 @code {
-    private List<ChatSession> Sessions = new();
-    private bool IsLoading = true;
-
     protected override async Task OnInitializedAsync()
     {
-        await LoadHistoryAsync();
-    }
-
-    private async Task LoadHistoryAsync()
-    {
-        try
-        {
-            IsLoading = true;
-            Sessions = await ChatService.GetChatHistoryAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.NotifyError($"❌ Error al cargar el historial: {ex.Message}");
-            Sessions = new List<ChatSession>();
-        }
-        finally
-        {
-            IsLoading = false;
-            StateHasChanged();
-        }
-    }
-
-    private void StartNewChat()
-    {
-        Navigation.NavigateTo("/");
-    }
-
-    private void OpenChat(string chatId)
-    {
-        Navigation.NavigateTo($"/chat/{chatId}", forceLoad: true);
-    }
-
-    private async Task DeleteChat(string chatId)
-    {
-        try
-        {
-            await ChatService.DeleteChatSessionAsync(chatId);
-            await LoadHistoryAsync();
-        }
-        catch (Exception ex)
-        {
-            NotificationService.NotifyError($"❌ Error al eliminar el chat: {ex.Message}");
-        }
+        await VM.LoadHistoryAsync();
     }
 }

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddMudServices();
 
 builder.Services.AddScoped<StateContainer>();
 builder.Services.AddScoped<ChatViewModel>();
+builder.Services.AddScoped<ChatHistoryViewModel>();
 builder.Services.AddScoped<HomeViewModel>();
 builder.Services.AddScoped<LoginViewModel>();
 builder.Services.AddScoped<ConnectionSettingsViewModel>();

--- a/SAPAssistant/ViewModels/ChatHistoryViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatHistoryViewModel.cs
@@ -1,0 +1,69 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.AspNetCore.Components;
+using SAPAssistant.Models;
+using SAPAssistant.Service;
+using SAPAssistant.Service.Interfaces;
+
+namespace SAPAssistant.ViewModels;
+
+public partial class ChatHistoryViewModel : BaseViewModel
+{
+    private readonly IChatHistoryService _chatService;
+    private readonly NavigationManager _navigation;
+    private readonly NotificationService _notificationService;
+
+    [ObservableProperty]
+    private List<ChatSession> sessions = new();
+
+    [ObservableProperty]
+    private bool isLoading = true;
+
+    public ChatHistoryViewModel(IChatHistoryService chatService, NavigationManager navigation, NotificationService notificationService)
+    {
+        _chatService = chatService;
+        _navigation = navigation;
+        _notificationService = notificationService;
+    }
+
+    public async Task LoadHistoryAsync()
+    {
+        try
+        {
+            IsLoading = true;
+            Sessions = await _chatService.GetChatHistoryAsync();
+        }
+        catch (Exception ex)
+        {
+            _notificationService.NotifyError($"❌ Error al cargar el historial: {ex.Message}");
+            Sessions = new List<ChatSession>();
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    public void StartNewChat()
+    {
+        _navigation.NavigateTo("/");
+    }
+
+    public void OpenChat(string chatId)
+    {
+        _navigation.NavigateTo($"/chat/{chatId}", forceLoad: true);
+    }
+
+    public async Task DeleteChat(string chatId)
+    {
+        try
+        {
+            await _chatService.DeleteChatSessionAsync(chatId);
+            await LoadHistoryAsync();
+        }
+        catch (Exception ex)
+        {
+            _notificationService.NotifyError($"❌ Error al eliminar el chat: {ex.Message}");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ChatHistoryViewModel to encapsulate loading, navigation, and deletion logic for chat sessions
- register ChatHistoryViewModel as a scoped service and inject it into the chat history component
- simplify ChatHistory.razor to delegate actions to the ViewModel

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688db16695b88320af407c01aeb672bc