### PR TITLE
Refactor session storage to use SessionContextService

### DIFF
--- a/SAPAssistant/Service/SessionContextService.cs
+++ b/SAPAssistant/Service/SessionContextService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using SAPAssistant.Models;
 
 namespace SAPAssistant.Service
 {
@@ -11,11 +12,18 @@ namespace SAPAssistant.Service
             _sessionStorage = sessionStorage;
         }
 
+        // ----- Autenticación -----
         public async Task<string?> GetUserIdAsync()
         {
             var result = await _sessionStorage.GetAsync<string>("username");
             return result.Success ? result.Value : null;
         }
+
+        public ValueTask SetUserIdAsync(string username)
+            => _sessionStorage.SetAsync("username", username);
+
+        public ValueTask DeleteUserIdAsync()
+            => _sessionStorage.DeleteAsync("username");
 
         public async Task<string?> GetTokenAsync()
         {
@@ -23,23 +31,61 @@ namespace SAPAssistant.Service
             return result.Success ? result.Value : null;
         }
 
+        public ValueTask SetTokenAsync(string token)
+            => _sessionStorage.SetAsync("token", token);
+
+        public ValueTask DeleteTokenAsync()
+            => _sessionStorage.DeleteAsync("token");
+
         public async Task<string?> GetRemoteIpAsync()
         {
             var result = await _sessionStorage.GetAsync<string>("remote_url");
             return result.Success ? result.Value?.TrimEnd('/') : null;
         }
 
+        public ValueTask SetRemoteIpAsync(string remoteUrl)
+            => _sessionStorage.SetAsync("remote_url", remoteUrl);
+
+        public ValueTask DeleteRemoteIpAsync()
+            => _sessionStorage.DeleteAsync("remote_url");
+
+        // ----- Conexión activa -----
         public async Task<string?> GetActiveConnectionIdAsync()
         {
             var result = await _sessionStorage.GetAsync<string>("active_connection_id");
             return result.Success ? result.Value : null;
         }
 
+        public ValueTask SetActiveConnectionIdAsync(string connectionId)
+            => _sessionStorage.SetAsync("active_connection_id", connectionId);
+
+        public ValueTask DeleteActiveConnectionIdAsync()
+            => _sessionStorage.DeleteAsync("active_connection_id");
+
         public async Task<string?> GetDatabaseTypeAsync()
         {
             var result = await _sessionStorage.GetAsync<string>("active_db_type");
             return result.Success ? result.Value : null;
         }
+
+        public ValueTask SetDatabaseTypeAsync(string dbType)
+            => _sessionStorage.SetAsync("active_db_type", dbType);
+
+        public ValueTask DeleteDatabaseTypeAsync()
+            => _sessionStorage.DeleteAsync("active_db_type");
+
+        // ----- Edición de conexión -----
+        public async Task<ConnectionDTO?> GetConnectionToEditAsync()
+        {
+            var result = await _sessionStorage.GetAsync<ConnectionDTO>("connection_to_edit");
+            return result.Success ? result.Value : null;
+        }
+
+        public ValueTask SetConnectionToEditAsync(ConnectionDTO connection)
+            => _sessionStorage.SetAsync("connection_to_edit", connection);
+
+        public ValueTask DeleteConnectionToEditAsync()
+            => _sessionStorage.DeleteAsync("connection_to_edit");
     }
 }
 

--- a/SAPAssistant/Shared/AssistantLayout.razor
+++ b/SAPAssistant/Shared/AssistantLayout.razor
@@ -1,4 +1,3 @@
-﻿@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using SAPAssistant.Security
 @using SAPAssistant.Service
 @using SAPAssistant.Service.Interfaces
@@ -7,7 +6,7 @@
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IConnectionService ConnectionService
-@inject ProtectedSessionStorage SessionStorage
+@inject SessionContextService SessionContext
 
 @if (isLoading || validandoConexion)
 {
@@ -95,13 +94,13 @@ else
         var currentUri = Navigation.ToBaseRelativePath(Navigation.Uri).ToLower();
         if (!currentUri.StartsWith("conexiones"))
         {
-            var result = await SessionStorage.GetAsync<string>("active_connection_id");
-            if (result.Success && !string.IsNullOrEmpty(result.Value))
+            var activeId = await SessionContext.GetActiveConnectionIdAsync();
+            if (!string.IsNullOrEmpty(activeId))
             {
-                var isValid = await ConnectionService.ValidateConnectionAsync(result.Value);
+                var isValid = await ConnectionService.ValidateConnectionAsync(activeId);
                 if (!isValid)
                 {
-                    await SessionStorage.DeleteAsync("active_connection_id");
+                    await SessionContext.DeleteActiveConnectionIdAsync();
                     Navigation.NavigateTo("/conexiones", true);
                     return;
                 }

--- a/SAPAssistant/Shared/ChatLayout.razor
+++ b/SAPAssistant/Shared/ChatLayout.razor
@@ -1,7 +1,6 @@
 ﻿@inherits LayoutComponentBase
 @attribute [Authorize]
 
-@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using SAPAssistant.Security
 @using SAPAssistant.Service
 @using SAPAssistant.Service.Interfaces
@@ -10,7 +9,7 @@
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IConnectionService ConnectionService
-@inject ProtectedSessionStorage SessionStorage
+@inject SessionContextService SessionContext
 
 @if (isLoading || validandoConexion)
 {
@@ -55,13 +54,13 @@ else
         var currentUri = Navigation.ToBaseRelativePath(Navigation.Uri).ToLower();
         if (!currentUri.StartsWith("conexiones"))
         {
-            var result = await SessionStorage.GetAsync<string>("active_connection_id");
-            if (result.Success && !string.IsNullOrEmpty(result.Value))
+            var activeId = await SessionContext.GetActiveConnectionIdAsync();
+            if (!string.IsNullOrEmpty(activeId))
             {
-                var isValid = await ConnectionService.ValidateConnectionAsync(result.Value);
+                var isValid = await ConnectionService.ValidateConnectionAsync(activeId);
                 if (!isValid)
                 {
-                    await SessionStorage.DeleteAsync("active_connection_id");
+                    await SessionContext.DeleteActiveConnectionIdAsync();
                     Navigation.NavigateTo("/conexiones", true);
                     return;
                 }

--- a/SAPAssistant/Shared/SettingsModal.razor
+++ b/SAPAssistant/Shared/SettingsModal.razor
@@ -1,5 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Components
-@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using SAPAssistant.Models
 @using SAPAssistant.Service
 @using SAPAssistant.Components.Connection

--- a/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using SAPAssistant.Models;
 using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
@@ -9,7 +8,7 @@ namespace SAPAssistant.ViewModels;
 
 public partial class ConnectionSettingsViewModel : BaseViewModel
 {
-    private readonly ProtectedSessionStorage _sessionStorage;
+    private readonly SessionContextService _sessionContext;
     private readonly IConnectionService _connectionService;
     private readonly NavigationManager _navigation;
     private readonly NotificationService _notificationService;
@@ -20,12 +19,12 @@ public partial class ConnectionSettingsViewModel : BaseViewModel
     public bool IsEditMode => !string.IsNullOrWhiteSpace(ConnectionData.ConnectionId);
 
     public ConnectionSettingsViewModel(
-        ProtectedSessionStorage sessionStorage,
+        SessionContextService sessionContext,
         IConnectionService connectionService,
         NavigationManager navigation,
         NotificationService notificationService)
     {
-        _sessionStorage = sessionStorage;
+        _sessionContext = sessionContext;
         _connectionService = connectionService;
         _navigation = navigation;
         _notificationService = notificationService;
@@ -33,11 +32,11 @@ public partial class ConnectionSettingsViewModel : BaseViewModel
 
     public async Task InitializeAsync()
     {
-        var result = await _sessionStorage.GetAsync<ConnectionDTO>("connection_to_edit");
-        if (result.Success && result.Value is not null)
+        var result = await _sessionContext.GetConnectionToEditAsync();
+        if (result is not null)
         {
-            ConnectionData = result.Value;
-            await _sessionStorage.DeleteAsync("connection_to_edit");
+            ConnectionData = result;
+            await _sessionContext.DeleteConnectionToEditAsync();
         }
     }
 


### PR DESCRIPTION
## Summary
- centralize session handling in `SessionContextService`
- replace `ProtectedSessionStorage` usage across layouts, view models, and auth logic
- sync `StateContainer.ActiveConnection` when a connection is activated

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688db31c8ff08320b0a1b93da0ee24b7