### PR TITLE
Add NotificationDisplay component to centralize alerts

### DIFF
--- a/SAPAssistant/Components/NotificationDisplay.razor
+++ b/SAPAssistant/Components/NotificationDisplay.razor
@@ -1,0 +1,33 @@
+@using SAPAssistant.Service
+@using SAPAssistant.Exceptions
+@implements IDisposable
+
+<AlertMessageError Result="@_message" OnClear="@ClearMessage" />
+
+@code {
+    [Inject] private NotificationService NotificationService { get; set; } = default!;
+
+    private ResultMessage? _message;
+
+    protected override void OnInitialized()
+    {
+        NotificationService.OnNotify += HandleNotification;
+    }
+
+    private void HandleNotification(ResultMessage message)
+    {
+        _message = message;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void ClearMessage()
+    {
+        _message = null;
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        NotificationService.OnNotify -= HandleNotification;
+    }
+}

--- a/SAPAssistant/Shared/MainLayout.razor
+++ b/SAPAssistant/Shared/MainLayout.razor
@@ -1,8 +1,10 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+@using SAPAssistant.Components
 
 <PageTitle>Iniciar sesión - SAPAssistant</PageTitle>
 
 <div class="login-layout">
+    <NotificationDisplay />
     <div class="login-card">
         @Body
     </div>

--- a/SAPAssistant/Shared/TestLayaout.razor
+++ b/SAPAssistant/Shared/TestLayaout.razor
@@ -1,9 +1,11 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 @using MudBlazor
+@using SAPAssistant.Components
 
 <MudThemeProvider>
     <MudDialogProvider />
     <MudSnackbarProvider />
+    <NotificationDisplay />
 
     <MudLayout>
         <MudAppBar Color="Color.Primary">


### PR DESCRIPTION
## Summary
- add NotificationDisplay component that subscribes to NotificationService and renders AlertMessageError
- use NotificationDisplay in MainLayout and TestLayaout for consistent toast display

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688dc4da780c8320a2afd257d2d6d26f