### PR TITLE
refactor: return operation results

### DIFF
--- a/SAPAssistant/Exceptions/OperationResult.cs
+++ b/SAPAssistant/Exceptions/OperationResult.cs
@@ -1,0 +1,42 @@
+namespace SAPAssistant.Exceptions
+{
+    public class OperationResult
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; } = string.Empty;
+        public string ErrorCode { get; set; } = string.Empty;
+
+        public static OperationResult Ok(string message = "") => new()
+        {
+            Success = true,
+            Message = message
+        };
+
+        public static OperationResult Fail(string message, string errorCode = "") => new()
+        {
+            Success = false,
+            Message = message,
+            ErrorCode = errorCode
+        };
+    }
+
+    public class OperationResult<T> : OperationResult
+    {
+        public T? Data { get; set; }
+
+        public static OperationResult<T> Ok(T data, string message = "") => new()
+        {
+            Success = true,
+            Message = message,
+            Data = data
+        };
+
+        public static new OperationResult<T> Fail(string message, string errorCode = "") => new()
+        {
+            Success = false,
+            Message = message,
+            ErrorCode = errorCode,
+            Data = default
+        };
+    }
+}

--- a/SAPAssistant/Security/ConnectionAuthorizationHandler.cs
+++ b/SAPAssistant/Security/ConnectionAuthorizationHandler.cs
@@ -33,8 +33,8 @@ namespace SAPAssistant.Security.Policies
                 return;
 
             // Validar conexión con el backend
-            var isValid = await _connectionService.ValidateConnectionAsync(activeId);
-            if (isValid)
+            var result = await _connectionService.ValidateConnectionAsync(activeId);
+            if (result.Success)
             {
                 context.Succeed(requirement);
             }

--- a/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
+++ b/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
@@ -1,12 +1,13 @@
 using SAPAssistant.Models;
 using SAPAssistant.Models.Chat;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.Service.Interfaces
 {
     public interface IChatHistoryService
     {
         Task<List<ChatSession>> GetChatHistoryAsync();
-        Task<ChatSession?> GetChatSessionAsync(string chatId);
+        Task<OperationResult<ChatSession>> GetChatSessionAsync(string chatId);
         Task SaveChatSessionAsync(ChatSession session, List<MessageBase> mensajes);
         Task DeleteChatSessionAsync(string chatId);
         Task<ChatSession?> GetLastChatSessionAsync();

--- a/SAPAssistant/Service/Interfaces/IConnectionService.cs
+++ b/SAPAssistant/Service/Interfaces/IConnectionService.cs
@@ -6,10 +6,10 @@ namespace SAPAssistant.Service.Interfaces
     public interface IConnectionService
     {
         Task<ResultMessage<List<ConnectionDTO>>> GetConnectionsAsync();
-        Task<ConnectionDTO?> GetConnectionByIdAsync(string connectionId);
-        Task<bool> UpdateConnectionAsync(ConnectionDTO connection);
-        Task<bool> CreateConnectionAsync(ConnectionDTO connection);
-        Task<bool> ValidateConnectionAsync(string connectionId);
+        Task<OperationResult<ConnectionDTO>> GetConnectionByIdAsync(string connectionId);
+        Task<OperationResult> UpdateConnectionAsync(ConnectionDTO connection);
+        Task<OperationResult> CreateConnectionAsync(ConnectionDTO connection);
+        Task<OperationResult> ValidateConnectionAsync(string connectionId);
     }
 }
 

--- a/SAPAssistant/Shared/AssistantLayout.razor
+++ b/SAPAssistant/Shared/AssistantLayout.razor
@@ -7,6 +7,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IConnectionService ConnectionService
 @inject SessionContextService SessionContext
+@inject NotificationService NotificationService
 
 @if (isLoading || validandoConexion)
 {
@@ -97,10 +98,11 @@ else
             var activeId = await SessionContext.GetActiveConnectionIdAsync();
             if (!string.IsNullOrEmpty(activeId))
             {
-                var isValid = await ConnectionService.ValidateConnectionAsync(activeId);
-                if (!isValid)
+                var validation = await ConnectionService.ValidateConnectionAsync(activeId);
+                if (!validation.Success)
                 {
                     await SessionContext.DeleteActiveConnectionIdAsync();
+                    NotificationService.NotifyError($"❌ {validation.Message}", validation.ErrorCode);
                     Navigation.NavigateTo("/conexiones", true);
                     return;
                 }

--- a/SAPAssistant/Shared/ChatLayout.razor
+++ b/SAPAssistant/Shared/ChatLayout.razor
@@ -10,6 +10,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IConnectionService ConnectionService
 @inject SessionContextService SessionContext
+@inject NotificationService NotificationService
 
 @if (isLoading || validandoConexion)
 {
@@ -57,10 +58,11 @@ else
             var activeId = await SessionContext.GetActiveConnectionIdAsync();
             if (!string.IsNullOrEmpty(activeId))
             {
-                var isValid = await ConnectionService.ValidateConnectionAsync(activeId);
-                if (!isValid)
+                var validation = await ConnectionService.ValidateConnectionAsync(activeId);
+                if (!validation.Success)
                 {
                     await SessionContext.DeleteActiveConnectionIdAsync();
+                    NotificationService.NotifyError($"❌ {validation.Message}", validation.ErrorCode);
                     Navigation.NavigateTo("/conexiones", true);
                     return;
                 }

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -62,7 +62,16 @@ public partial class ChatViewModel : BaseViewModel
 
         if (!string.IsNullOrWhiteSpace(chatId))
         {
-            CurrentSession = await _chatHistoryService.GetChatSessionAsync(chatId);
+            var result = await _chatHistoryService.GetChatSessionAsync(chatId);
+            if (result.Success)
+            {
+                CurrentSession = result.Data;
+            }
+            else
+            {
+                NotificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
+                return;
+            }
         }
         else
         {

--- a/SAPAssistant/ViewModels/ConnectionManagerViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionManagerViewModel.cs
@@ -80,10 +80,11 @@ public partial class ConnectionManagerViewModel : BaseViewModel
 
         try
         {
-            var isValid = await _connectionService.ValidateConnectionAsync(connection.ConnectionId);
-            if (!isValid)
+            var result = await _connectionService.ValidateConnectionAsync(connection.ConnectionId);
+            if (!result.Success)
             {
                 MostrarError = true;
+                NotificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
                 await Task.Delay(3000);
                 MostrarError = false;
                 return false;

--- a/SAPAssistant/ViewModels/ConnectionSelectionViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionSelectionViewModel.cs
@@ -35,8 +35,8 @@ public partial class ConnectionSelectionViewModel : BaseViewModel
         var activeId = await _sessionContext.GetActiveConnectionIdAsync();
         if (!string.IsNullOrEmpty(activeId))
         {
-            var isValid = await _connectionService.ValidateConnectionAsync(activeId);
-            if (isValid)
+            var result = await _connectionService.ValidateConnectionAsync(activeId);
+            if (result.Success)
             {
                 HayConexionActiva = true;
             }
@@ -45,6 +45,7 @@ public partial class ConnectionSelectionViewModel : BaseViewModel
                 HayConexionActiva = false;
                 MostrarAviso = true;
                 await _sessionContext.DeleteActiveConnectionIdAsync();
+                NotificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
             }
         }
     }

--- a/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using SAPAssistant.Models;
 using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.ViewModels;
 
@@ -44,24 +45,25 @@ public partial class ConnectionSettingsViewModel : BaseViewModel
 
     public async Task HandleSave()
     {
-        bool success;
+        OperationResult result;
 
         if (IsEditMode)
         {
-            success = await _connectionService.UpdateConnectionAsync(ConnectionData);
+            result = await _connectionService.UpdateConnectionAsync(ConnectionData);
         }
         else
         {
-            success = await _connectionService.CreateConnectionAsync(ConnectionData);
+            result = await _connectionService.CreateConnectionAsync(ConnectionData);
         }
 
-        if (success)
+        if (result.Success)
         {
+            _notificationService.NotifySuccess(result.Message);
             _navigation.NavigateTo("/");
         }
         else
         {
-            _notificationService.NotifyError("❌ Error al guardar la conexión.");
+            _notificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add OperationResult types for service feedback
- return detailed OperationResult from connection and chat history services
- evaluate OperationResult.Success in consumers and notify via NotificationService

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688e6526bc7c8320b637a0c64a0f1ac3