### PR TITLE
Add localization resources and map error codes to translated messages

### DIFF
--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Authorization;
 using SAPAssistant.Exceptions;
 using MudBlazor.Services;
 using SAPAssistant.ViewModels;
+using System.Globalization;
+using Microsoft.AspNetCore.Localization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +23,7 @@ var apiBaseUrl = builder.Configuration["ApiBaseUrl"]
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor()
  .AddCircuitOptions(options => { options.DetailedErrors = true; });
+builder.Services.AddLocalization(options => options.ResourcesPath = "Resources");
 builder.Services.AddHttpClient("Default", client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
@@ -90,6 +93,14 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();
+var supportedCultures = new[] { new CultureInfo("en"), new CultureInfo("es") };
+var localizationOptions = new RequestLocalizationOptions
+{
+    DefaultRequestCulture = new("es"),
+    SupportedCultures = supportedCultures,
+    SupportedUICultures = supportedCultures
+};
+app.UseRequestLocalization(localizationOptions);
 app.UseRouting();
 
 app.MapBlazorHub();

--- a/SAPAssistant/Resources/ErrorMessages.cs
+++ b/SAPAssistant/Resources/ErrorMessages.cs
@@ -1,0 +1,7 @@
+namespace SAPAssistant.Resources
+{
+    // Marker class for shared resource localization
+    public class ErrorMessages
+    {
+    }
+}

--- a/SAPAssistant/Resources/ErrorMessages.en.resx
+++ b/SAPAssistant/Resources/ErrorMessages.en.resx
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AUTH-401" xml:space="preserve"><value>Invalid username or password.</value></data>
+  <data name="SVC-UNAVAILABLE" xml:space="preserve"><value>The system is unavailable. Please try again later.</value></data>
+  <data name="AUTH-INVALID-RESPONSE" xml:space="preserve"><value>Unable to process server response.</value></data>
+  <data name="LOGIN-SUCCESS" xml:space="preserve"><value>Login successful.</value></data>
+  <data name="NET-ERROR" xml:space="preserve"><value>Connection problem. Check your internet connection.</value></data>
+  <data name="UNEXPECTED-ERROR" xml:space="preserve"><value>Unexpected error. Please try again.</value></data>
+  <data name="SESSION-TOKEN-NOT-FOUND" xml:space="preserve"><value>Token not found in session.</value></data>
+  <data name="SESSION-USER-NOT-FOUND" xml:space="preserve"><value>User not found in session.</value></data>
+  <data name="SESSION-REMOTE_IP-NOT-FOUND" xml:space="preserve"><value>User remote IP not found in session.</value></data>
+  <data name="CONNECTIONS-FETCH-ERROR" xml:space="preserve"><value>Error fetching connections from server.</value></data>
+  <data name="CONNECTIONS-FETCH-SUCCESS" xml:space="preserve"><value>Connections retrieved successfully.</value></data>
+  <data name="SESSION-DATA-NOT-FOUND" xml:space="preserve"><value>User or remote IP not found in session.</value></data>
+  <data name="CONNECTION-FETCH-ERROR" xml:space="preserve"><value>Error fetching the connection from server.</value></data>
+  <data name="EMPTY-RESPONSE" xml:space="preserve"><value>Empty response from server.</value></data>
+  <data name="CONNECTION-FETCH-SUCCESS" xml:space="preserve"><value>Connection retrieved successfully.</value></data>
+  <data name="UPDATE-CONNECTION-ERROR" xml:space="preserve"><value>Error updating connection.</value></data>
+  <data name="CONNECTION-UPDATED" xml:space="preserve"><value>Connection updated successfully.</value></data>
+  <data name="CREATE-CONNECTION-ERROR" xml:space="preserve"><value>Error creating connection.</value></data>
+  <data name="CONNECTION-CREATED" xml:space="preserve"><value>Connection created successfully.</value></data>
+  <data name="VALIDATION-CONNECTION-ERROR" xml:space="preserve"><value>Invalid connection.</value></data>
+  <data name="CONNECTION-VALID" xml:space="preserve"><value>Connection valid.</value></data>
+  <data name="CHAT-FETCH-ERROR" xml:space="preserve"><value>Error fetching chat.</value></data>
+  <data name="CHAT-FETCH-SUCCESS" xml:space="preserve"><value>Chat retrieved successfully.</value></data>
+  <data name="CHAT-HISTORY-LOAD-ERROR" xml:space="preserve"><value>Error loading history.</value></data>
+  <data name="CHAT-SAVE-ERROR" xml:space="preserve"><value>Error saving chat.</value></data>
+  <data name="CHAT-DELETE-ERROR" xml:space="preserve"><value>Error deleting chat.</value></data>
+  <data name="UNKNOWN-MESSAGE-TYPE" xml:space="preserve"><value>Unknown message type.</value></data>
+  <data name="NEW-CHAT-TITLE" xml:space="preserve"><value>New chat</value></data>
+</root>

--- a/SAPAssistant/Resources/ErrorMessages.es.resx
+++ b/SAPAssistant/Resources/ErrorMessages.es.resx
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AUTH-401" xml:space="preserve"><value>Usuario o contraseña incorrectos.</value></data>
+  <data name="SVC-UNAVAILABLE" xml:space="preserve"><value>El sistema no está disponible. Intenta más tarde.</value></data>
+  <data name="AUTH-INVALID-RESPONSE" xml:space="preserve"><value>No se pudo procesar la respuesta del servidor.</value></data>
+  <data name="LOGIN-SUCCESS" xml:space="preserve"><value>Inicio de sesión exitoso.</value></data>
+  <data name="NET-ERROR" xml:space="preserve"><value>Problema de conexión. Verifique su conexión a Internet.</value></data>
+  <data name="UNEXPECTED-ERROR" xml:space="preserve"><value>Error inesperado. Por favor, intente nuevamente.</value></data>
+  <data name="SESSION-TOKEN-NOT-FOUND" xml:space="preserve"><value>Token no encontrado en la sesión.</value></data>
+  <data name="SESSION-USER-NOT-FOUND" xml:space="preserve"><value>Usuario no encontrado en la sesión.</value></data>
+  <data name="SESSION-REMOTE_IP-NOT-FOUND" xml:space="preserve"><value>IP remota del usuario no encontrada en la sesión.</value></data>
+  <data name="CONNECTIONS-FETCH-ERROR" xml:space="preserve"><value>Error al obtener las conexiones desde el servidor.</value></data>
+  <data name="CONNECTIONS-FETCH-SUCCESS" xml:space="preserve"><value>Conexiones obtenidas exitosamente.</value></data>
+  <data name="SESSION-DATA-NOT-FOUND" xml:space="preserve"><value>Usuario o IP remota no encontrada en la sesión.</value></data>
+  <data name="CONNECTION-FETCH-ERROR" xml:space="preserve"><value>Error al obtener la conexión desde el servidor.</value></data>
+  <data name="EMPTY-RESPONSE" xml:space="preserve"><value>Respuesta vacía del servidor.</value></data>
+  <data name="CONNECTION-FETCH-SUCCESS" xml:space="preserve"><value>Conexión obtenida exitosamente.</value></data>
+  <data name="UPDATE-CONNECTION-ERROR" xml:space="preserve"><value>Error al actualizar la conexión.</value></data>
+  <data name="CONNECTION-UPDATED" xml:space="preserve"><value>Conexión actualizada correctamente.</value></data>
+  <data name="CREATE-CONNECTION-ERROR" xml:space="preserve"><value>Error al crear la conexión.</value></data>
+  <data name="CONNECTION-CREATED" xml:space="preserve"><value>Conexión creada correctamente.</value></data>
+  <data name="VALIDATION-CONNECTION-ERROR" xml:space="preserve"><value>Conexión inválida.</value></data>
+  <data name="CONNECTION-VALID" xml:space="preserve"><value>Conexión válida.</value></data>
+  <data name="CHAT-FETCH-ERROR" xml:space="preserve"><value>Error al obtener el chat.</value></data>
+  <data name="CHAT-FETCH-SUCCESS" xml:space="preserve"><value>Chat obtenido exitosamente.</value></data>
+  <data name="CHAT-HISTORY-LOAD-ERROR" xml:space="preserve"><value>Error al cargar historial.</value></data>
+  <data name="CHAT-SAVE-ERROR" xml:space="preserve"><value>Error al guardar chat.</value></data>
+  <data name="CHAT-DELETE-ERROR" xml:space="preserve"><value>Error al eliminar chat.</value></data>
+  <data name="UNKNOWN-MESSAGE-TYPE" xml:space="preserve"><value>Tipo de mensaje desconocido.</value></data>
+  <data name="NEW-CHAT-TITLE" xml:space="preserve"><value>Nuevo chat</value></data>
+</root>

--- a/SAPAssistant/Service/AuthService.cs
+++ b/SAPAssistant/Service/AuthService.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using SAPAssistant.Resources;
 
 namespace SAPAssistant.Service
 {
@@ -13,11 +15,13 @@ namespace SAPAssistant.Service
     {
         private readonly HttpClient _http;
         private readonly CustomAuthStateProvider _authProvider;
+        private readonly IStringLocalizer<ErrorMessages> _localizer;
 
-        public AuthService(HttpClient http, CustomAuthStateProvider authProvider)
+        public AuthService(HttpClient http, CustomAuthStateProvider authProvider, IStringLocalizer<ErrorMessages> localizer)
         {
             _http = http;
             _authProvider = authProvider;
+            _localizer = localizer;
         }
 
         public async Task<ResultMessage<LoginResponse>> LoginAsync(LoginRequest request)
@@ -27,32 +31,39 @@ namespace SAPAssistant.Service
                 var response = await _http.PostAsJsonAsync("/login", request);
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
                 {
-                    return ResultMessage<LoginResponse>.Fail("Usuario o contraseña incorrectos.", "AUTH-401");
+                    const string code = "AUTH-401";
+                    return ResultMessage<LoginResponse>.Fail(_localizer[code], code);
                 }
 
                 if (!response.IsSuccessStatusCode)
                 {
-                    return ResultMessage<LoginResponse>.Fail("El sistema no está disponible. Intenta más tarde.", $"SVC-{(int)response.StatusCode}");
+                    const string code = "SVC-UNAVAILABLE";
+                    return ResultMessage<LoginResponse>.Fail(_localizer[code], code);
                 }
 
                 var user = await response.Content.ReadFromJsonAsync<LoginResponse>();
                 if (user is null)
                 {
-                    return ResultMessage<LoginResponse>.Fail("No se pudo procesar la respuesta del servidor.", "AUTH-INVALID-RESPONSE");
+                    const string code = "AUTH-INVALID-RESPONSE";
+                    return ResultMessage<LoginResponse>.Fail(_localizer[code], code);
                 }
 
                 await _authProvider.MarkUserAsAuthenticated(user.Username, user.Token);
                 await _authProvider.SaveRemoteUrlAsync(user.remote_url); // ✅ Guardar remote_url
 
-                return ResultMessage<LoginResponse>.Ok(user, "Inicio de sesión exitoso.");
+                var ok = ResultMessage<LoginResponse>.Ok(user, _localizer["LOGIN-SUCCESS"]);
+                ok.ErrorCode = "LOGIN-SUCCESS";
+                return ok;
             }
             catch (HttpRequestException)
             {
-                return ResultMessage<LoginResponse>.Fail("Problema de conexión. Verifique su conexión a Internet.", "NET-ERROR");
+                const string code = "NET-ERROR";
+                return ResultMessage<LoginResponse>.Fail(_localizer[code], code);
             }
             catch (Exception)
             {
-                return ResultMessage<LoginResponse>.Fail("Error inesperado. Por favor, intente nuevamente.", "UNEXPECTED-ERROR");
+                const string code = "UNEXPECTED-ERROR";
+                return ResultMessage<LoginResponse>.Fail(_localizer[code], code);
             }
         }
 

--- a/SAPAssistant/Service/NotificationService.cs
+++ b/SAPAssistant/Service/NotificationService.cs
@@ -2,16 +2,20 @@ using System;
 using Microsoft.Extensions.Logging;
 using SAPAssistant.Exceptions;
 using SAPAssistant.Service.Interfaces;
+using Microsoft.Extensions.Localization;
+using SAPAssistant.Resources;
 
 namespace SAPAssistant.Service;
 
 public class NotificationService : INotificationService
 {
     private readonly ILogger<NotificationService> _logger;
+    private readonly IStringLocalizer<ErrorMessages> _localizer;
 
-    public NotificationService(ILogger<NotificationService> logger)
+    public NotificationService(ILogger<NotificationService> logger, IStringLocalizer<ErrorMessages> localizer)
     {
         _logger = logger;
+        _localizer = localizer;
     }
 
     // Evento al que se suscriben los componentes que muestran mensajes
@@ -20,6 +24,15 @@ public class NotificationService : INotificationService
     // Método para emitir mensajes de notificación
     public void Notify(ResultMessage message)
     {
+        if (!string.IsNullOrEmpty(message.ErrorCode))
+        {
+            var localized = _localizer[message.ErrorCode];
+            if (!localized.ResourceNotFound)
+            {
+                message.Message = localized;
+            }
+        }
+
         OnNotify?.Invoke(message);
     }
 

--- a/SAPAssistant/ViewModels/ConnectionManagerViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionManagerViewModel.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components;
 using SAPAssistant.Models;
 using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.ViewModels;
 
@@ -56,7 +57,7 @@ public partial class ConnectionManagerViewModel : BaseViewModel
         }
         else
         {
-            ErrorAlCargar = $"❌ {result.Message} (Código: {result.ErrorCode})";
+            ErrorAlCargar = result.Message;
         }
     }
 
@@ -82,7 +83,14 @@ public partial class ConnectionManagerViewModel : BaseViewModel
             if (!result.Success)
             {
                 MostrarError = true;
-                NotificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
+                var notify = new ResultMessage
+                {
+                    Success = result.Success,
+                    Message = result.Message,
+                    ErrorCode = result.ErrorCode,
+                    Type = NotificationType.Error
+                };
+                NotificationService.Notify(notify);
                 await Task.Delay(3000);
                 MostrarError = false;
                 return false;

--- a/SAPAssistant/ViewModels/ConnectionSelectionViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionSelectionViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.AspNetCore.Components;
 using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.ViewModels;
 
@@ -43,7 +44,14 @@ public partial class ConnectionSelectionViewModel : BaseViewModel
                 HayConexionActiva = false;
                 MostrarAviso = true;
                 await _sessionContext.DeleteActiveConnectionIdAsync();
-                NotificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
+                var notify = new ResultMessage
+                {
+                    Success = result.Success,
+                    Message = result.Message,
+                    ErrorCode = result.ErrorCode,
+                    Type = NotificationType.Error
+                };
+                NotificationService.Notify(notify);
             }
         }
     }

--- a/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
+++ b/SAPAssistant/ViewModels/ConnectionSettingsViewModel.cs
@@ -54,14 +54,19 @@ public partial class ConnectionSettingsViewModel : BaseViewModel
             result = await _connectionService.CreateConnectionAsync(ConnectionData);
         }
 
+        var notify = new ResultMessage
+        {
+            Success = result.Success,
+            Message = result.Message,
+            ErrorCode = result.ErrorCode,
+            Type = result.Success ? NotificationType.Success : NotificationType.Error
+        };
+
+        _notificationService.Notify(notify);
+
         if (result.Success)
         {
-            _notificationService.NotifySuccess(result.Message);
             _navigation.NavigateTo("/");
-        }
-        else
-        {
-            _notificationService.NotifyError($"❌ {result.Message}", result.ErrorCode);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add centralized resource files for multilingual error messages
- localize services and view models via `IStringLocalizer`
- resolve notification texts from `ResultMessage.ErrorCode`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688e73f289208320a79118d11bb8ba03