### PR TITLE
Rename ResultMessage to ChatResultMessage

### DIFF
--- a/SAPAssistant/Components/Chat/ResultCardListComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultCardListComponent.razor
@@ -56,7 +56,7 @@
 @code {
     [Parameter] public MessageBase Message { get; set; }
     [Parameter] public EventCallback<string> OnViewTypeChange { get; set; }
-    private ResultMessage M => (ResultMessage)Message;
+    private ChatResultMessage M => (ChatResultMessage)Message;
 
     private bool MostrarSql { get; set; } = false;
 

--- a/SAPAssistant/Components/Chat/ResultChartComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultChartComponent.razor
@@ -79,7 +79,7 @@
     [Parameter] public MessageBase Message { get; set; }
     [Parameter] public EventCallback<string> OnViewTypeChange { get; set; }
 
-    private ResultMessage M => (ResultMessage)Message;
+    private ChatResultMessage M => (ChatResultMessage)Message;
     private bool MostrarSql { get; set; }
 
     private ChartType SelectedChartType = ChartType.Bar;

--- a/SAPAssistant/Components/Chat/ResultGridComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultGridComponent.razor
@@ -105,7 +105,7 @@
 @code {
     [Parameter] public MessageBase Message { get; set; }
     [Parameter] public EventCallback<string> OnViewTypeChange { get; set; }
-    private ResultMessage M => (ResultMessage)Message;
+    private ChatResultMessage M => (ChatResultMessage)Message;
 
     private bool MostrarSql { get; set; }
     private string? AlertText { get; set; }

--- a/SAPAssistant/Components/Chat/ResultKpiComponent.razor
+++ b/SAPAssistant/Components/Chat/ResultKpiComponent.razor
@@ -36,7 +36,7 @@
 @code {
     [Parameter] public MessageBase Message { get; set; }
     [Parameter] public EventCallback<string> OnViewTypeChange { get; set; }
-    private ResultMessage M => (ResultMessage)Message;
+    private ChatResultMessage M => (ChatResultMessage)Message;
 
     private async Task ChangeViewType(ChangeEventArgs e)
     {

--- a/SAPAssistant/Models/Chat/ChatResultMessage.cs
+++ b/SAPAssistant/Models/Chat/ChatResultMessage.cs
@@ -1,6 +1,6 @@
 ﻿namespace SAPAssistant.Models.Chat
 {
-    public class ResultMessage : MessageBase
+    public class ChatResultMessage : MessageBase
     {
         public string Resumen { get; set; } = string.Empty;
         public string Sql { get; set; } = string.Empty;

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -8,7 +8,6 @@ using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
 using System.Text.Json;
 using SAPAssistant.Exceptions;
-using ChatResultMessage = SAPAssistant.Models.Chat.ResultMessage;
 using Microsoft.Extensions.Localization;
 using SAPAssistant;
 


### PR DESCRIPTION
## Summary
- rename ResultMessage model to ChatResultMessage
- update chat components and view model to use ChatResultMessage and remove alias

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_689b75b19c0883208356ceeaff159e6c