### PR TITLE
Standardize service method signatures to return ServiceResult

### DIFF
--- a/SAPAssistant/Service/Interfaces/IAssistantService.cs
+++ b/SAPAssistant/Service/Interfaces/IAssistantService.cs
@@ -1,11 +1,12 @@
 using SAPAssistant.Models;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.Service.Interfaces
 {
     public interface IAssistantService
     {
-        Task<QueryResponse?> ConsultarAsync(string mensaje, string chatId);
-        Task<QueryResponse?> ConsultarDemoAsync(string mensaje);
+        Task<ServiceResult<QueryResponse>> ConsultarAsync(string mensaje, string chatId);
+        Task<ServiceResult<QueryResponse>> ConsultarDemoAsync(string mensaje);
     }
 }
 

--- a/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
+++ b/SAPAssistant/Service/Interfaces/IChatHistoryService.cs
@@ -6,10 +6,10 @@ namespace SAPAssistant.Service.Interfaces
 {
     public interface IChatHistoryService
     {
-        Task<List<ChatSession>> GetChatHistoryAsync();
+        Task<ServiceResult<List<ChatSession>>> GetChatHistoryAsync();
         Task<ServiceResult<ChatSession>> GetChatSessionAsync(string chatId);
-        Task SaveChatSessionAsync(ChatSession session, List<MessageBase> mensajes);
-        Task DeleteChatSessionAsync(string chatId);
-        Task<ChatSession?> GetLastChatSessionAsync();
+        Task<ServiceResult> SaveChatSessionAsync(ChatSession session, List<MessageBase> mensajes);
+        Task<ServiceResult> DeleteChatSessionAsync(string chatId);
+        Task<ServiceResult<ChatSession>> GetLastChatSessionAsync();
     }
 }

--- a/SAPAssistant/Service/Interfaces/IUserDashboardService.cs
+++ b/SAPAssistant/Service/Interfaces/IUserDashboardService.cs
@@ -1,10 +1,11 @@
 using SAPAssistant.Models;
+using SAPAssistant.Exceptions;
 
 namespace SAPAssistant.Service.Interfaces
 {
     public interface IUserDashboardService
     {
-        Task AddKpiAsync(DashboardCardModel kpi);
+        Task<ServiceResult> AddKpiAsync(DashboardCardModel kpi);
     }
 }
 

--- a/SAPAssistant/Service/UserDashboardService.cs
+++ b/SAPAssistant/Service/UserDashboardService.cs
@@ -19,25 +19,35 @@ namespace SAPAssistant.Service
             _logger = logger;
         }
 
-        public async Task AddKpiAsync(DashboardCardModel kpi)
+        public async Task<ServiceResult> AddKpiAsync(DashboardCardModel kpi)
         {
-            var userId = await _sessionContext.GetUserIdAsync();
-            if (string.IsNullOrWhiteSpace(userId))
+            try
             {
-                _logger.LogError("Usuario no encontrado en la sesión.");
-                throw new DashboardServiceException("Usuario no encontrado en la sesión.");
+                var userId = await _sessionContext.GetUserIdAsync();
+                if (string.IsNullOrWhiteSpace(userId))
+                {
+                    _logger.LogError("Usuario no encontrado en la sesión.");
+                    return ServiceResult.Fail("Usuario no encontrado en la sesión.", "SESSION-USER-NOT-FOUND");
+                }
+
+                var request = new HttpRequestMessage(HttpMethod.Post, "/user-dashboard/kpis");
+                request.Headers.Add("X-User-Id", userId);
+                request.Content = JsonContent.Create(kpi);
+
+                var response = await _http.SendAsync(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    _logger.LogError("Error al agregar KPI: {StatusCode} - {Error}", response.StatusCode, error);
+                    return ServiceResult.Fail($"Error al agregar KPI: {response.StatusCode} - {error}");
+                }
+
+                return ServiceResult.Ok();
             }
-
-            var request = new HttpRequestMessage(HttpMethod.Post, "/user-dashboard/kpis");
-            request.Headers.Add("X-User-Id", userId);
-            request.Content = JsonContent.Create(kpi);
-
-            var response = await _http.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
+            catch (Exception ex)
             {
-                var error = await response.Content.ReadAsStringAsync();
-                _logger.LogError("Error al agregar KPI: {StatusCode} - {Error}", response.StatusCode, error);
-                throw new DashboardServiceException($"Error al agregar KPI: {response.StatusCode} - {error}");
+                _logger.LogError(ex, "Error al agregar KPI");
+                return ServiceResult.Fail("Error al agregar KPI");
             }
         }
     }

--- a/SAPAssistant/ViewModels/ChatHistoryViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatHistoryViewModel.cs
@@ -29,14 +29,15 @@ public partial class ChatHistoryViewModel : BaseViewModel
     public async Task LoadHistoryAsync()
     {
         IsLoading = true;
-        var success = await TryNotifyAsync(async () =>
+        var result = await _chatService.GetChatHistoryAsync();
+        if (result.Success && result.Data != null)
         {
-            Sessions = await _chatService.GetChatHistoryAsync();
-        }, "Error al cargar el historial");
-
-        if (!success)
+            Sessions = result.Data;
+        }
+        else
         {
             Sessions = new List<ChatSession>();
+            await NotificationService.Notify(result);
         }
         IsLoading = false;
     }
@@ -53,11 +54,14 @@ public partial class ChatHistoryViewModel : BaseViewModel
 
     public async Task DeleteChat(string chatId)
     {
-        await TryNotifyAsync(async () =>
+        var result = await _chatService.DeleteChatSessionAsync(chatId);
+        if (!result.Success)
         {
-            await _chatService.DeleteChatSessionAsync(chatId);
-            await LoadHistoryAsync();
-        }, "Error al eliminar el chat");
+            await NotificationService.Notify(result);
+            return;
+        }
+
+        await LoadHistoryAsync();
     }
 }
 

--- a/SAPAssistant/ViewModels/DashboardCatalogViewModel.cs
+++ b/SAPAssistant/ViewModels/DashboardCatalogViewModel.cs
@@ -112,9 +112,10 @@ public partial class DashboardCatalogViewModel : BaseViewModel
         };
 
         DashboardService.KPIs.Add(copy);
-        await TryNotifyAsync(async () =>
+        var result = await _userDashboardService.AddKpiAsync(copy);
+        if (!result.Success)
         {
-            await _userDashboardService.AddKpiAsync(copy);
-        }, "Error al agregar KPI");
+            await NotificationService.Notify(result);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Ensure service interfaces return `ServiceResult`/`ServiceResult<T>` and update implementations
- Refactor assistant, chat history, and user dashboard services to produce `ServiceResult`
- Adapt chat, chat history, and dashboard catalog view models to consume the unified results

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b77260d64832096f7fea38954d519