### PR TITLE
Propagate notification types from services

### DIFF
--- a/SAPAssistant/Service/Shared/Mapping/EnvelopeMapper.cs
+++ b/SAPAssistant/Service/Shared/Mapping/EnvelopeMapper.cs
@@ -21,7 +21,8 @@ public static class EnvelopeMapper
     {
         if (env.Success && env.Data is not null)
         {
-            var ok = ServiceResult<T>.Ok(env.Data, localizer[okKey]);
+            var type = env.NotificationType ?? NotificationType.Success;
+            var ok = ServiceResult<T>.Ok(env.Data, localizer[okKey], type);
             ok.ErrorCode = "OK";
             ok.CorrelationId = correlationId;
             ok.TraceId = env.TraceId;
@@ -35,7 +36,8 @@ public static class EnvelopeMapper
             ? localizer[code].Value
             : (!string.IsNullOrWhiteSpace(env.Error) ? env.Error! : localizer["GENERIC_ERROR"].Value);
 
-        var fail = ServiceResult<T>.Fail(message, code);
+        var failType = env.NotificationType ?? NotificationType.Error;
+        var fail = ServiceResult<T>.Fail(message, code, failType);
         fail.CorrelationId = correlationId;
         fail.TraceId = env.TraceId;
         return fail;

--- a/SAPAssistant/Service/Shared/Transport/StdResponse.cs
+++ b/SAPAssistant/Service/Shared/Transport/StdResponse.cs
@@ -1,23 +1,26 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
+using SAPAssistant.Exceptions;
 
-namespace SAPAssistant.Service.Shared.Transport
+namespace SAPAssistant.Service.Shared.Transport;
+
+// DTO de transporte (no sale de esta capa)
+public class StdResponse<T>
 {
-    // DTO de transporte (no sale de esta capa)
-    public  class StdResponse<T>
-    {
-        [JsonPropertyName("success")]
-        public bool Success { get; set; }
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
 
-        [JsonPropertyName("data")]
-        public T? Data { get; set; }
+    [JsonPropertyName("data")]
+    public T? Data { get; set; }
 
-        [JsonPropertyName("error")]
-        public string? Error { get; set; }
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
 
-        [JsonPropertyName("errorCode")]
-        public string? ErrorCode { get; set; }
+    [JsonPropertyName("errorCode")]
+    public string? ErrorCode { get; set; }
 
-        [JsonPropertyName("traceId")]
-        public string? TraceId { get; set; }
-    }
+    [JsonPropertyName("traceId")]
+    public string? TraceId { get; set; }
+
+    [JsonPropertyName("notificationType")]
+    public NotificationType? NotificationType { get; set; }
 }


### PR DESCRIPTION
## Summary
- Add optional `notificationType` field to the standard API envelope
- Map backend notification types into `ServiceResult` so UI receives explicit type

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b79980dc08320bca3d3c9f8adc8e8