### PR TITLE
refactor: centralize error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ sap_assistant_blazor/
 └── Program.cs / Startup.cs  # Configuración de la aplicación
 ```
 
+### Manejo de errores
+
+Las claves de error utilizadas en los servicios y la interfaz se centralizan en `Constants/ErrorCodes.cs`. Estas constantes se utilizan como referencias para las claves de localización definidas en los archivos `Resources/ErrorMessages*.resx`.
+
 ---
 
 ## 📚 Funcionalidades

--- a/SAPAssistant/Constants/ErrorCodes.cs
+++ b/SAPAssistant/Constants/ErrorCodes.cs
@@ -1,0 +1,40 @@
+namespace SAPAssistant.Constants;
+
+/// <summary>
+/// Provides string constants for error and status codes used throughout the application.
+/// The values match keys in localization resource files.
+/// </summary>
+public static class ErrorCodes
+{
+    public const string SESSION_TOKEN_NOT_FOUND = nameof(SESSION_TOKEN_NOT_FOUND);
+    public const string SESSION_USER_NOT_FOUND = nameof(SESSION_USER_NOT_FOUND);
+    public const string SESSION_REMOTE_IP_NOT_FOUND = nameof(SESSION_REMOTE_IP_NOT_FOUND);
+    public const string CONNECTIONS_FETCH_ERROR = nameof(CONNECTIONS_FETCH_ERROR);
+    public const string CONNECTIONS_FETCH_SUCCESS = nameof(CONNECTIONS_FETCH_SUCCESS);
+    public const string NET_ERROR = nameof(NET_ERROR);
+    public const string UNEXPECTED_ERROR = nameof(UNEXPECTED_ERROR);
+    public const string SESSION_DATA_NOT_FOUND = nameof(SESSION_DATA_NOT_FOUND);
+    public const string CONNECTION_FETCH_ERROR = nameof(CONNECTION_FETCH_ERROR);
+    public const string EMPTY_RESPONSE = nameof(EMPTY_RESPONSE);
+    public const string CONNECTION_FETCH_SUCCESS = nameof(CONNECTION_FETCH_SUCCESS);
+    public const string UPDATE_CONNECTION_ERROR = nameof(UPDATE_CONNECTION_ERROR);
+    public const string CONNECTION_UPDATED = nameof(CONNECTION_UPDATED);
+    public const string CREATE_CONNECTION_ERROR = nameof(CREATE_CONNECTION_ERROR);
+    public const string CONNECTION_CREATED = nameof(CONNECTION_CREATED);
+    public const string VALIDATION_CONNECTION_ERROR = nameof(VALIDATION_CONNECTION_ERROR);
+    public const string CONNECTION_VALID = nameof(CONNECTION_VALID);
+    public const string CHAT_HISTORY_LOAD_ERROR = nameof(CHAT_HISTORY_LOAD_ERROR);
+    public const string CHAT_FETCH_ERROR = nameof(CHAT_FETCH_ERROR);
+    public const string CHAT_FETCH_SUCCESS = nameof(CHAT_FETCH_SUCCESS);
+    public const string CHAT_SAVE_ERROR = nameof(CHAT_SAVE_ERROR);
+    public const string CHAT_DELETE_ERROR = nameof(CHAT_DELETE_ERROR);
+    public const string OK = nameof(OK);
+    public const string SVC_UNAVAILABLE = nameof(SVC_UNAVAILABLE);
+    public const string FE_NETWORK_HTTP = nameof(FE_NETWORK_HTTP);
+    public const string FE_NETWORK_TIMEOUT = nameof(FE_NETWORK_TIMEOUT);
+    public const string FE_NETWORK_ERROR = nameof(FE_NETWORK_ERROR);
+    public const string GENERIC_ERROR = nameof(GENERIC_ERROR);
+    public const string INTERNAL_ERROR = nameof(INTERNAL_ERROR);
+    public const string LOGIN_SUCCESS = nameof(LOGIN_SUCCESS);
+    public const string NEW_CHAT_TITLE = nameof(NEW_CHAT_TITLE);
+}

--- a/SAPAssistant/Resources/ErrorMessages.en.resx
+++ b/SAPAssistant/Resources/ErrorMessages.en.resx
@@ -1,47 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
+  
+  
   <resheader name="resmimetype">
+    
+    
     <value>text/microsoft-resx</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="version">
+    
+    
     <value>2.0</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="reader">
+    
+    
     <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="writer">
+    
+    
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    
+  
   </resheader>
-  <data name="AUTH-401" xml:space="preserve"><value>Invalid username or password.</value></data>
-  <data name="SVC-UNAVAILABLE" xml:space="preserve"><value>The system is unavailable. Please try again later.</value></data>
-  <data name="AUTH-INVALID-RESPONSE" xml:space="preserve"><value>Unable to process server response.</value></data>
-  <data name="LOGIN-SUCCESS" xml:space="preserve"><value>Login successful.</value></data>
-  <data name="NET-ERROR" xml:space="preserve"><value>Connection problem. Check your internet connection.</value></data>
-  <data name="UNEXPECTED-ERROR" xml:space="preserve"><value>Unexpected error. Please try again.</value></data>
-  <data name="SESSION-TOKEN-NOT-FOUND" xml:space="preserve"><value>Token not found in session.</value></data>
-  <data name="SESSION-USER-NOT-FOUND" xml:space="preserve"><value>User not found in session.</value></data>
-  <data name="SESSION-REMOTE_IP-NOT-FOUND" xml:space="preserve"><value>User remote IP not found in session.</value></data>
-  <data name="CONNECTIONS-FETCH-ERROR" xml:space="preserve"><value>Error fetching connections from server.</value></data>
-  <data name="CONNECTIONS-FETCH-SUCCESS" xml:space="preserve"><value>Connections retrieved successfully.</value></data>
-  <data name="SESSION-DATA-NOT-FOUND" xml:space="preserve"><value>User or remote IP not found in session.</value></data>
-  <data name="CONNECTION-FETCH-ERROR" xml:space="preserve"><value>Error fetching the connection from server.</value></data>
-  <data name="EMPTY-RESPONSE" xml:space="preserve"><value>Empty response from server.</value></data>
-  <data name="CONNECTION-FETCH-SUCCESS" xml:space="preserve"><value>Connection retrieved successfully.</value></data>
-  <data name="UPDATE-CONNECTION-ERROR" xml:space="preserve"><value>Error updating connection.</value></data>
-  <data name="CONNECTION-UPDATED" xml:space="preserve"><value>Connection updated successfully.</value></data>
-  <data name="CREATE-CONNECTION-ERROR" xml:space="preserve"><value>Error creating connection.</value></data>
-  <data name="CONNECTION-CREATED" xml:space="preserve"><value>Connection created successfully.</value></data>
-  <data name="VALIDATION-CONNECTION-ERROR" xml:space="preserve"><value>Invalid connection.</value></data>
-  <data name="CONNECTION-VALID" xml:space="preserve"><value>Connection valid.</value></data>
-  <data name="CHAT-FETCH-ERROR" xml:space="preserve"><value>Error fetching chat.</value></data>
-  <data name="CHAT-FETCH-SUCCESS" xml:space="preserve"><value>Chat retrieved successfully.</value></data>
-  <data name="CHAT-HISTORY-LOAD-ERROR" xml:space="preserve"><value>Error loading history.</value></data>
-  <data name="CHAT-SAVE-ERROR" xml:space="preserve"><value>Error saving chat.</value></data>
-  <data name="CHAT-DELETE-ERROR" xml:space="preserve"><value>Error deleting chat.</value></data>
-  <data name="UNKNOWN-MESSAGE-TYPE" xml:space="preserve"><value>Unknown message type.</value></data>
-  <data name="NEW-CHAT-TITLE" xml:space="preserve"><value>New chat</value></data>
-  <data name="AUTH-USER-REQUIRED" xml:space="preserve"><value>Username is required.</value></data>
-  <data name="AUTH-PASSWORD-REQUIRED" xml:space="preserve"><value>Password is required.</value></data>
-  <data name="NET-ERROR" xml:space="preserve"><value>Could not connect to the server. Please try again later.</value></data>
-
+  
+  
+  <data name="AUTH_401" xml:space="preserve">
+    <value>Invalid username or password.</value>
+  </data>
+  
+  
+  <data name="SVC_UNAVAILABLE" xml:space="preserve">
+    <value>The system is unavailable. Please try again later.</value>
+  </data>
+  
+  
+  <data name="AUTH_INVALID_RESPONSE" xml:space="preserve">
+    <value>Unable to process server response.</value>
+  </data>
+  
+  
+  <data name="LOGIN_SUCCESS" xml:space="preserve">
+    <value>Login successful.</value>
+  </data>
+  
+  
+  <data name="NET_ERROR" xml:space="preserve">
+    <value>Connection problem. Check your internet connection.</value>
+  </data>
+  
+  
+  <data name="UNEXPECTED_ERROR" xml:space="preserve">
+    <value>Unexpected error. Please try again.</value>
+  </data>
+  
+  
+  <data name="SESSION_TOKEN_NOT_FOUND" xml:space="preserve">
+    <value>Token not found in session.</value>
+  </data>
+  
+  
+  <data name="SESSION_USER_NOT_FOUND" xml:space="preserve">
+    <value>User not found in session.</value>
+  </data>
+  
+  
+  <data name="SESSION_REMOTE_IP_NOT_FOUND" xml:space="preserve">
+    <value>User remote IP not found in session.</value>
+  </data>
+  
+  
+  <data name="CONNECTIONS_FETCH_ERROR" xml:space="preserve">
+    <value>Error fetching connections from server.</value>
+  </data>
+  
+  
+  <data name="CONNECTIONS_FETCH_SUCCESS" xml:space="preserve">
+    <value>Connections retrieved successfully.</value>
+  </data>
+  
+  
+  <data name="SESSION_DATA_NOT_FOUND" xml:space="preserve">
+    <value>User or remote IP not found in session.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_FETCH_ERROR" xml:space="preserve">
+    <value>Error fetching the connection from server.</value>
+  </data>
+  
+  
+  <data name="EMPTY_RESPONSE" xml:space="preserve">
+    <value>Empty response from server.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_FETCH_SUCCESS" xml:space="preserve">
+    <value>Connection retrieved successfully.</value>
+  </data>
+  
+  
+  <data name="UPDATE_CONNECTION_ERROR" xml:space="preserve">
+    <value>Error updating connection.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_UPDATED" xml:space="preserve">
+    <value>Connection updated successfully.</value>
+  </data>
+  
+  
+  <data name="CREATE_CONNECTION_ERROR" xml:space="preserve">
+    <value>Error creating connection.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_CREATED" xml:space="preserve">
+    <value>Connection created successfully.</value>
+  </data>
+  
+  
+  <data name="VALIDATION_CONNECTION_ERROR" xml:space="preserve">
+    <value>Invalid connection.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_VALID" xml:space="preserve">
+    <value>Connection valid.</value>
+  </data>
+  
+  
+  <data name="CHAT_FETCH_ERROR" xml:space="preserve">
+    <value>Error fetching chat.</value>
+  </data>
+  
+  
+  <data name="CHAT_FETCH_SUCCESS" xml:space="preserve">
+    <value>Chat retrieved successfully.</value>
+  </data>
+  
+  
+  <data name="CHAT_HISTORY_LOAD_ERROR" xml:space="preserve">
+    <value>Error loading history.</value>
+  </data>
+  
+  
+  <data name="CHAT_SAVE_ERROR" xml:space="preserve">
+    <value>Error saving chat.</value>
+  </data>
+  
+  
+  <data name="CHAT_DELETE_ERROR" xml:space="preserve">
+    <value>Error deleting chat.</value>
+  </data>
+  
+  
+  <data name="UNKNOWN_MESSAGE_TYPE" xml:space="preserve">
+    <value>Unknown message type.</value>
+  </data>
+  
+  
+  <data name="NEW_CHAT_TITLE" xml:space="preserve">
+    <value>New chat</value>
+  </data>
+  
+  
+  <data name="AUTH_USER_REQUIRED" xml:space="preserve">
+    <value>Username is required.</value>
+  </data>
+  
+  
+  <data name="AUTH_PASSWORD_REQUIRED" xml:space="preserve">
+    <value>Password is required.</value>
+  </data>
+  
+  
+  <data name="FE_NETWORK_HTTP" xml:space="preserve">
+    <value>HTTP network error on frontend.</value>
+  </data>
+  <data name="FE_NETWORK_TIMEOUT" xml:space="preserve">
+    <value>Network timeout on frontend.</value>
+  </data>
+  <data name="FE_NETWORK_ERROR" xml:space="preserve">
+    <value>Network error on frontend.</value>
+  </data>
+  <data name="GENERIC_ERROR" xml:space="preserve">
+    <value>An error occurred.</value>
+  </data>
+  <data name="INTERNAL_ERROR" xml:space="preserve">
+    <value>Internal error.</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Operation successful.</value>
+  </data>
 </root>

--- a/SAPAssistant/Resources/ErrorMessages.resx
+++ b/SAPAssistant/Resources/ErrorMessages.resx
@@ -1,46 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
+  
+  
   <resheader name="resmimetype">
+    
+    
     <value>text/microsoft-resx</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="version">
+    
+    
     <value>2.0</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="reader">
+    
+    
     <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    
+  
   </resheader>
+  
+  
   <resheader name="writer">
+    
+    
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    
+  
   </resheader>
-  <data name="AUTH-401" xml:space="preserve"><value>Usuario o contraseña incorrectos.</value></data>
-  <data name="SVC-UNAVAILABLE" xml:space="preserve"><value>El sistema no está disponible. Intenta más tarde.</value></data>
-  <data name="AUTH-INVALID-RESPONSE" xml:space="preserve"><value>No se pudo procesar la respuesta del servidor.</value></data>
-  <data name="LOGIN-SUCCESS" xml:space="preserve"><value>Inicio de sesión exitoso.</value></data>
-  <data name="NET-ERROR" xml:space="preserve"><value>Problema de conexión. Verifique su conexión a Internet.</value></data>
-  <data name="UNEXPECTED-ERROR" xml:space="preserve"><value>Error inesperado. Por favor, intente nuevamente.</value></data>
-  <data name="SESSION-TOKEN-NOT-FOUND" xml:space="preserve"><value>Token no encontrado en la sesión.</value></data>
-  <data name="SESSION-USER-NOT-FOUND" xml:space="preserve"><value>Usuario no encontrado en la sesión.</value></data>
-  <data name="SESSION-REMOTE_IP-NOT-FOUND" xml:space="preserve"><value>IP remota del usuario no encontrada en la sesión.</value></data>
-  <data name="CONNECTIONS-FETCH-ERROR" xml:space="preserve"><value>Error al obtener las conexiones desde el servidor.</value></data>
-  <data name="CONNECTIONS-FETCH-SUCCESS" xml:space="preserve"><value>Conexiones obtenidas exitosamente.</value></data>
-  <data name="SESSION-DATA-NOT-FOUND" xml:space="preserve"><value>Usuario o IP remota no encontrada en la sesión.</value></data>
-  <data name="CONNECTION-FETCH-ERROR" xml:space="preserve"><value>Error al obtener la conexión desde el servidor.</value></data>
-  <data name="EMPTY-RESPONSE" xml:space="preserve"><value>Respuesta vacía del servidor.</value></data>
-  <data name="CONNECTION-FETCH-SUCCESS" xml:space="preserve"><value>Conexión obtenida exitosamente.</value></data>
-  <data name="UPDATE-CONNECTION-ERROR" xml:space="preserve"><value>Error al actualizar la conexión.</value></data>
-  <data name="CONNECTION-UPDATED" xml:space="preserve"><value>Conexión actualizada correctamente.</value></data>
-  <data name="CREATE-CONNECTION-ERROR" xml:space="preserve"><value>Error al crear la conexión.</value></data>
-  <data name="CONNECTION-CREATED" xml:space="preserve"><value>Conexión creada correctamente.</value></data>
-  <data name="VALIDATION-CONNECTION-ERROR" xml:space="preserve"><value>Conexión inválida.</value></data>
-  <data name="CONNECTION-VALID" xml:space="preserve"><value>Conexión válida.</value></data>
-  <data name="CHAT-FETCH-ERROR" xml:space="preserve"><value>Error al obtener el chat.</value></data>
-  <data name="CHAT-FETCH-SUCCESS" xml:space="preserve"><value>Chat obtenido exitosamente.</value></data>
-  <data name="CHAT-HISTORY-LOAD-ERROR" xml:space="preserve"><value>Error al cargar historial.</value></data>
-  <data name="CHAT-SAVE-ERROR" xml:space="preserve"><value>Error al guardar chat.</value></data>
-  <data name="CHAT-DELETE-ERROR" xml:space="preserve"><value>Error al eliminar chat.</value></data>
-  <data name="UNKNOWN-MESSAGE-TYPE" xml:space="preserve"><value>Tipo de mensaje desconocido.</value></data>
-  <data name="NEW-CHAT-TITLE" xml:space="preserve"><value>Nuevo chat</value></data>
-  <data name="AUTH-USER-REQUIRED" xml:space="preserve"><value>El usuario es obligatorio.</value></data>
-  <data name="AUTH-PASSWORD-REQUIRED" xml:space="preserve"><value>La contraseña es obligatoria.</value></data>
-  <data name="NET-ERROR" xml:space="preserve"><value>No se ha podido conectar con el servidor. Inténtalo más tarde.</value></data>
+  
+  
+  <data name="AUTH_401" xml:space="preserve">
+    <value>Usuario o contraseña incorrectos.</value>
+  </data>
+  
+  
+  <data name="SVC_UNAVAILABLE" xml:space="preserve">
+    <value>El sistema no está disponible. Intenta más tarde.</value>
+  </data>
+  
+  
+  <data name="AUTH_INVALID_RESPONSE" xml:space="preserve">
+    <value>No se pudo procesar la respuesta del servidor.</value>
+  </data>
+  
+  
+  <data name="LOGIN_SUCCESS" xml:space="preserve">
+    <value>Inicio de sesión exitoso.</value>
+  </data>
+  
+  
+  <data name="NET_ERROR" xml:space="preserve">
+    <value>Problema de conexión. Verifique su conexión a Internet.</value>
+  </data>
+  
+  
+  <data name="UNEXPECTED_ERROR" xml:space="preserve">
+    <value>Error inesperado. Por favor, intente nuevamente.</value>
+  </data>
+  
+  
+  <data name="SESSION_TOKEN_NOT_FOUND" xml:space="preserve">
+    <value>Token no encontrado en la sesión.</value>
+  </data>
+  
+  
+  <data name="SESSION_USER_NOT_FOUND" xml:space="preserve">
+    <value>Usuario no encontrado en la sesión.</value>
+  </data>
+  
+  
+  <data name="SESSION_REMOTE_IP_NOT_FOUND" xml:space="preserve">
+    <value>IP remota del usuario no encontrada en la sesión.</value>
+  </data>
+  
+  
+  <data name="CONNECTIONS_FETCH_ERROR" xml:space="preserve">
+    <value>Error al obtener las conexiones desde el servidor.</value>
+  </data>
+  
+  
+  <data name="CONNECTIONS_FETCH_SUCCESS" xml:space="preserve">
+    <value>Conexiones obtenidas exitosamente.</value>
+  </data>
+  
+  
+  <data name="SESSION_DATA_NOT_FOUND" xml:space="preserve">
+    <value>Usuario o IP remota no encontrada en la sesión.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_FETCH_ERROR" xml:space="preserve">
+    <value>Error al obtener la conexión desde el servidor.</value>
+  </data>
+  
+  
+  <data name="EMPTY_RESPONSE" xml:space="preserve">
+    <value>Respuesta vacía del servidor.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_FETCH_SUCCESS" xml:space="preserve">
+    <value>Conexión obtenida exitosamente.</value>
+  </data>
+  
+  
+  <data name="UPDATE_CONNECTION_ERROR" xml:space="preserve">
+    <value>Error al actualizar la conexión.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_UPDATED" xml:space="preserve">
+    <value>Conexión actualizada correctamente.</value>
+  </data>
+  
+  
+  <data name="CREATE_CONNECTION_ERROR" xml:space="preserve">
+    <value>Error al crear la conexión.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_CREATED" xml:space="preserve">
+    <value>Conexión creada correctamente.</value>
+  </data>
+  
+  
+  <data name="VALIDATION_CONNECTION_ERROR" xml:space="preserve">
+    <value>Conexión inválida.</value>
+  </data>
+  
+  
+  <data name="CONNECTION_VALID" xml:space="preserve">
+    <value>Conexión válida.</value>
+  </data>
+  
+  
+  <data name="CHAT_FETCH_ERROR" xml:space="preserve">
+    <value>Error al obtener el chat.</value>
+  </data>
+  
+  
+  <data name="CHAT_FETCH_SUCCESS" xml:space="preserve">
+    <value>Chat obtenido exitosamente.</value>
+  </data>
+  
+  
+  <data name="CHAT_HISTORY_LOAD_ERROR" xml:space="preserve">
+    <value>Error al cargar historial.</value>
+  </data>
+  
+  
+  <data name="CHAT_SAVE_ERROR" xml:space="preserve">
+    <value>Error al guardar chat.</value>
+  </data>
+  
+  
+  <data name="CHAT_DELETE_ERROR" xml:space="preserve">
+    <value>Error al eliminar chat.</value>
+  </data>
+  
+  
+  <data name="UNKNOWN_MESSAGE_TYPE" xml:space="preserve">
+    <value>Tipo de mensaje desconocido.</value>
+  </data>
+  
+  
+  <data name="NEW_CHAT_TITLE" xml:space="preserve">
+    <value>Nuevo chat</value>
+  </data>
+  
+  
+  <data name="AUTH_USER_REQUIRED" xml:space="preserve">
+    <value>El usuario es obligatorio.</value>
+  </data>
+  
+  
+  <data name="AUTH_PASSWORD_REQUIRED" xml:space="preserve">
+    <value>La contraseña es obligatoria.</value>
+  </data>
+  
+  
+  <data name="FE_NETWORK_HTTP" xml:space="preserve">
+    <value>Error de red HTTP en el frontend.</value>
+  </data>
+  <data name="FE_NETWORK_TIMEOUT" xml:space="preserve">
+    <value>Tiempo de espera agotado en el frontend.</value>
+  </data>
+  <data name="FE_NETWORK_ERROR" xml:space="preserve">
+    <value>Error de red en el frontend.</value>
+  </data>
+  <data name="GENERIC_ERROR" xml:space="preserve">
+    <value>Ocurrió un error.</value>
+  </data>
+  <data name="INTERNAL_ERROR" xml:space="preserve">
+    <value>Error interno.</value>
+  </data>
+  <data name="OK" xml:space="preserve">
+    <value>Operación exitosa.</value>
+  </data>
 </root>

--- a/SAPAssistant/Service/AuthService.cs
+++ b/SAPAssistant/Service/AuthService.cs
@@ -3,6 +3,7 @@ using SAPAssistant.Models;
 using SAPAssistant.Security;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Localization;
+using SAPAssistant.Constants;
 
 
 namespace SAPAssistant.Service
@@ -25,7 +26,7 @@ namespace SAPAssistant.Service
             var r = await _api.PostAsResultAsync<LoginRequest, LoginResponse>(
                 "login",            // SIN /api/v1/ porque ya va en BaseAddress
                 request,
-                okKey: "LOGIN_SUCCESS",
+                okKey: ErrorCodes.LOGIN_SUCCESS,
                 ct
             );
 

--- a/SAPAssistant/Service/ChatHistoryService.cs
+++ b/SAPAssistant/Service/ChatHistoryService.cs
@@ -7,6 +7,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.Localization;
 using SAPAssistant;
+using SAPAssistant.Constants;
 
 namespace SAPAssistant.Service
 {
@@ -28,7 +29,7 @@ namespace SAPAssistant.Service
         private async Task<string> GetUserIdAsync()
         {
             var userId = await _sessionContext.GetUserIdAsync();
-            if (string.IsNullOrEmpty(userId)) throw new ChatHistoryServiceException(_localizer["SESSION-USER-NOT-FOUND"]);
+            if (string.IsNullOrEmpty(userId)) throw new ChatHistoryServiceException(_localizer[ErrorCodes.SESSION_USER_NOT_FOUND]);
             return userId;
         }
 
@@ -46,7 +47,7 @@ namespace SAPAssistant.Service
                 {
                     var error = await response.Content.ReadAsStringAsync();
                     _logger.LogError("[ChatService] Error HTTP {StatusCode}: {Error}", response.StatusCode, error);
-                    const string code = "CHAT-HISTORY-LOAD-ERROR";
+                    const string code = ErrorCodes.CHAT_HISTORY_LOAD_ERROR;
                     return ServiceResult<List<ChatSession>>.Fail(_localizer[code], code);
                 }
 
@@ -55,13 +56,13 @@ namespace SAPAssistant.Service
             }
             catch (ChatHistoryServiceException ex)
             {
-                const string code = "SESSION-USER-NOT-FOUND";
+                const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
                 return ServiceResult<List<ChatSession>>.Fail(ex.Message, code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "[ChatService] Excepción al obtener historial");
-                const string code = "CHAT-HISTORY-LOAD-ERROR";
+                const string code = ErrorCodes.CHAT_HISTORY_LOAD_ERROR;
                 return ServiceResult<List<ChatSession>>.Fail(_localizer[code], code);
             }
         }
@@ -81,30 +82,30 @@ namespace SAPAssistant.Service
                 {
                     var errorMessage = await response.Content.ReadAsStringAsync();
                     _logger.LogError("[ChatService] Error HTTP {StatusCode}: {Error}", response.StatusCode, errorMessage);
-                    const string code = "CHAT-FETCH-ERROR";
+                    const string code = ErrorCodes.CHAT_FETCH_ERROR;
                     return ServiceResult<ChatSession>.Fail(_localizer[code], code);
                 }
 
                 var chat = await response.Content.ReadFromJsonAsync<ChatSession>();
                 if (chat == null)
                 {
-                    const string code = "EMPTY-RESPONSE";
+                    const string code = ErrorCodes.EMPTY_RESPONSE;
                     return ServiceResult<ChatSession>.Fail(_localizer[code], code);
                 }
 
-                var ok = ServiceResult<ChatSession>.Ok(chat, _localizer["CHAT-FETCH-SUCCESS"]);
-                ok.ErrorCode = "CHAT-FETCH-SUCCESS";
+                var ok = ServiceResult<ChatSession>.Ok(chat, _localizer[ErrorCodes.CHAT_FETCH_SUCCESS]);
+                ok.ErrorCode = ErrorCodes.CHAT_FETCH_SUCCESS;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<ChatSession>.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "[ChatService] Excepción inesperada al obtener el chat '{ChatId}'", chatId);
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult<ChatSession>.Fail(_localizer[code], code);
             }
         }
@@ -128,7 +129,7 @@ namespace SAPAssistant.Service
                 {
                     var error = await response.Content.ReadAsStringAsync();
                     _logger.LogError("[ChatService] Error HTTP {StatusCode}: {Error}", response.StatusCode, error);
-                    const string code = "CHAT-SAVE-ERROR";
+                    const string code = ErrorCodes.CHAT_SAVE_ERROR;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
@@ -136,13 +137,13 @@ namespace SAPAssistant.Service
             }
             catch (ChatHistoryServiceException ex)
             {
-                const string code = "SESSION-USER-NOT-FOUND";
+                const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
                 return ServiceResult.Fail(ex.Message, code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "[ChatService] Excepción al guardar chat");
-                const string code = "CHAT-SAVE-ERROR";
+                const string code = ErrorCodes.CHAT_SAVE_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
         }
@@ -161,7 +162,7 @@ namespace SAPAssistant.Service
                 {
                     var error = await response.Content.ReadAsStringAsync();
                     _logger.LogError("[ChatService] Error HTTP {StatusCode}: {Error}", response.StatusCode, error);
-                    const string code = "CHAT-DELETE-ERROR";
+                    const string code = ErrorCodes.CHAT_DELETE_ERROR;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
@@ -169,13 +170,13 @@ namespace SAPAssistant.Service
             }
             catch (ChatHistoryServiceException ex)
             {
-                const string code = "SESSION-USER-NOT-FOUND";
+                const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
                 return ServiceResult.Fail(ex.Message, code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "[ChatService] Excepción al eliminar chat");
-                const string code = "CHAT-DELETE-ERROR";
+                const string code = ErrorCodes.CHAT_DELETE_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
         }
@@ -191,7 +192,7 @@ namespace SAPAssistant.Service
             var last = history.Data?.OrderByDescending(s => s.Fecha).FirstOrDefault();
             if (last == null)
             {
-                const string code = "EMPTY-RESPONSE";
+                const string code = ErrorCodes.EMPTY_RESPONSE;
                 return ServiceResult<ChatSession>.Fail(_localizer[code], code);
             }
 

--- a/SAPAssistant/Service/ConnectionService.cs
+++ b/SAPAssistant/Service/ConnectionService.cs
@@ -7,6 +7,7 @@ using SAPAssistant.Service.Interfaces;
 
 using Microsoft.Extensions.Localization;
 using SAPAssistant;
+using SAPAssistant.Constants;
 
 namespace SAPAssistant.Service
 {
@@ -38,19 +39,19 @@ namespace SAPAssistant.Service
 
                 if (string.IsNullOrWhiteSpace(token))
                 {
-                    const string code = "SESSION-TOKEN-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_TOKEN_NOT_FOUND;
                     return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
                 }
 
                 if (string.IsNullOrWhiteSpace(userId))
                 {
-                    const string code = "SESSION-USER-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
                     return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
                 }
 
                 if (string.IsNullOrWhiteSpace(remoteIp))
                 {
-                    const string code = "SESSION-REMOTE_IP-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_REMOTE_IP_NOT_FOUND;
                     return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
                 }
 
@@ -61,26 +62,26 @@ namespace SAPAssistant.Service
                 var response = await _http.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
                 {
-                    const string code = "CONNECTIONS-FETCH-ERROR";
+                    const string code = ErrorCodes.CONNECTIONS_FETCH_ERROR;
                     return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
                 }
 
                 var rawList = await response.Content.ReadFromJsonAsync<List<Dictionary<string, ConnectionDTO>>>();
                 var connections = ConnectionMapper.FromRawList(rawList ?? new());
 
-                var ok = ServiceResult<List<ConnectionDTO>>.Ok(connections, _localizer["CONNECTIONS-FETCH-SUCCESS"]);
-                ok.ErrorCode = "CONNECTIONS-FETCH-SUCCESS";
+                var ok = ServiceResult<List<ConnectionDTO>>.Ok(connections, _localizer[ErrorCodes.CONNECTIONS_FETCH_SUCCESS]);
+                ok.ErrorCode = ErrorCodes.CONNECTIONS_FETCH_SUCCESS;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al obtener conexiones");
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
             }
         }
@@ -94,7 +95,7 @@ namespace SAPAssistant.Service
 
                 if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
                 {
-                    const string code = "SESSION-DATA-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
                 }
 
@@ -105,30 +106,30 @@ namespace SAPAssistant.Service
                 var response = await _http.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
                 {
-                    const string code = "CONNECTION-FETCH-ERROR";
+                    const string code = ErrorCodes.CONNECTION_FETCH_ERROR;
                     return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
                 }
 
                 var dto = await response.Content.ReadFromJsonAsync<ConnectionDTO>();
                 if (dto == null)
                 {
-                    const string code = "EMPTY-RESPONSE";
+                    const string code = ErrorCodes.EMPTY_RESPONSE;
                     return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
                 }
 
-                var ok = ServiceResult<ConnectionDTO>.Ok(dto, _localizer["CONNECTION-FETCH-SUCCESS"]);
-                ok.ErrorCode = "CONNECTION-FETCH-SUCCESS";
+                var ok = ServiceResult<ConnectionDTO>.Ok(dto, _localizer[ErrorCodes.CONNECTION_FETCH_SUCCESS]);
+                ok.ErrorCode = ErrorCodes.CONNECTION_FETCH_SUCCESS;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al obtener conexión {ConnectionId}", connectionId);
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
             }
         }
@@ -142,7 +143,7 @@ namespace SAPAssistant.Service
 
                 if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
                 {
-                    const string code = "SESSION-DATA-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
@@ -154,23 +155,23 @@ namespace SAPAssistant.Service
                 var response = await _http.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
                 {
-                    const string code = "UPDATE-CONNECTION-ERROR";
+                    const string code = ErrorCodes.UPDATE_CONNECTION_ERROR;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
-                var ok = ServiceResult.Ok(_localizer["CONNECTION-UPDATED"]);
-                ok.ErrorCode = "CONNECTION-UPDATED";
+                var ok = ServiceResult.Ok(_localizer[ErrorCodes.CONNECTION_UPDATED]);
+                ok.ErrorCode = ErrorCodes.CONNECTION_UPDATED;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al actualizar conexión {ConnectionId}", connection.ConnectionId);
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
         }
@@ -184,7 +185,7 @@ namespace SAPAssistant.Service
 
                 if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
                 {
-                    const string code = "SESSION-DATA-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
@@ -196,23 +197,23 @@ namespace SAPAssistant.Service
                 var response = await _http.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
                 {
-                    const string code = "CREATE-CONNECTION-ERROR";
+                    const string code = ErrorCodes.CREATE_CONNECTION_ERROR;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
-                var ok = ServiceResult.Ok(_localizer["CONNECTION-CREATED"]);
-                ok.ErrorCode = "CONNECTION-CREATED";
+                var ok = ServiceResult.Ok(_localizer[ErrorCodes.CONNECTION_CREATED]);
+                ok.ErrorCode = ErrorCodes.CONNECTION_CREATED;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al crear conexión");
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
         }
@@ -225,7 +226,7 @@ namespace SAPAssistant.Service
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
                 if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
                 {
-                    const string code = "SESSION-DATA-NOT-FOUND";
+                    const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
@@ -241,23 +242,23 @@ namespace SAPAssistant.Service
                                      connectionId,
                                      response.StatusCode,
                                      errorContent);
-                    const string code = "VALIDATION-CONNECTION-ERROR";
+                    const string code = ErrorCodes.VALIDATION_CONNECTION_ERROR;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
-                var ok = ServiceResult.Ok(_localizer["CONNECTION-VALID"]);
-                ok.ErrorCode = "CONNECTION-VALID";
+                var ok = ServiceResult.Ok(_localizer[ErrorCodes.CONNECTION_VALID]);
+                ok.ErrorCode = ErrorCodes.CONNECTION_VALID;
                 return ok;
             }
             catch (HttpRequestException)
             {
-                const string code = "NET-ERROR";
+                const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al validar conexión {ConnectionId}", connectionId);
-                const string code = "UNEXPECTED-ERROR";
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
         }

--- a/SAPAssistant/Service/Shared/Hptt/HttpClientExtensions.cs
+++ b/SAPAssistant/Service/Shared/Hptt/HttpClientExtensions.cs
@@ -6,6 +6,7 @@ using Infrastructure.Mapping;
 using SAPAssistant.Exceptions;
 using SAPAssistant.Service.Shared.Transport;
 using SAPAssistant;
+using SAPAssistant.Constants;
 
 public class ApiClient
 {
@@ -21,7 +22,7 @@ public class ApiClient
     public async Task<ServiceResult<TRes>> PostAsResultAsync<TReq, TRes>(
         string url,
         TReq body,
-        string okKey = "OK",
+        string okKey = ErrorCodes.OK,
         CancellationToken ct = default)
     {
         var corr = Guid.NewGuid().ToString();
@@ -47,23 +48,23 @@ public class ApiClient
 
             // Sin envelope → errores “físicos” del front
             if ((int)res.StatusCode is 502 or 503 or 504)
-                return ServiceResult<TRes>.Fail(_localizer["SVC_UNAVAILABLE"], "SVC_UNAVAILABLE")
+                return ServiceResult<TRes>.Fail(_localizer[ErrorCodes.SVC_UNAVAILABLE], ErrorCodes.SVC_UNAVAILABLE)
                                           .WithCorrelation(corr)
                                           .WithTrace(corr);
 
-            return ServiceResult<TRes>.Fail(_localizer["FE_NETWORK_HTTP"], "FE_NETWORK_HTTP")
+            return ServiceResult<TRes>.Fail(_localizer[ErrorCodes.FE_NETWORK_HTTP], ErrorCodes.FE_NETWORK_HTTP)
                                       .WithCorrelation(corr)
                                       .WithTrace(corr);
         }
         catch (TaskCanceledException)
         {
-            return ServiceResult<TRes>.Fail(_localizer["FE_NETWORK_TIMEOUT"], "FE_NETWORK_TIMEOUT")
+            return ServiceResult<TRes>.Fail(_localizer[ErrorCodes.FE_NETWORK_TIMEOUT], ErrorCodes.FE_NETWORK_TIMEOUT)
                                       .WithCorrelation(corr)
                                       .WithTrace(corr);
         }
         catch (HttpRequestException)
         {
-            return ServiceResult<TRes>.Fail(_localizer["FE_NETWORK_ERROR"], "FE_NETWORK_ERROR")
+            return ServiceResult<TRes>.Fail(_localizer[ErrorCodes.FE_NETWORK_ERROR], ErrorCodes.FE_NETWORK_ERROR)
                                       .WithCorrelation(corr)
                                       .WithTrace(corr);
         }

--- a/SAPAssistant/Service/Shared/Mapping/EnvelopeMapper.cs
+++ b/SAPAssistant/Service/Shared/Mapping/EnvelopeMapper.cs
@@ -2,6 +2,7 @@
 using SAPAssistant.Exceptions;
 using SAPAssistant.Service.Shared.Transport;
 using SAPAssistant;
+using SAPAssistant.Constants;
 
 namespace Infrastructure.Mapping;
 
@@ -17,24 +18,24 @@ public static class EnvelopeMapper
         this StdResponse<T> env,
         IStringLocalizer<ErrorMessages> localizer,
         string? correlationId = null,
-        string okKey = "OK")
+        string okKey = ErrorCodes.OK)
     {
         if (env.Success && env.Data is not null)
         {
             var type = env.NotificationType ?? NotificationType.Success;
             var ok = ServiceResult<T>.Ok(env.Data, localizer[okKey], type);
-            ok.ErrorCode = "OK";
+            ok.ErrorCode = ErrorCodes.OK;
             ok.CorrelationId = correlationId;
             ok.TraceId = env.TraceId;
             return ok;
         }
 
-        var code = string.IsNullOrWhiteSpace(env.ErrorCode) ? "INTERNAL_ERROR" : env.ErrorCode!;
+        var code = string.IsNullOrWhiteSpace(env.ErrorCode) ? ErrorCodes.INTERNAL_ERROR : env.ErrorCode!;
         var hasTranslation = localizer.GetString(code).ResourceNotFound == false;
 
         var message = hasTranslation
             ? localizer[code].Value
-            : (!string.IsNullOrWhiteSpace(env.Error) ? env.Error! : localizer["GENERIC_ERROR"].Value);
+            : (!string.IsNullOrWhiteSpace(env.Error) ? env.Error! : localizer[ErrorCodes.GENERIC_ERROR].Value);
 
         var failType = env.NotificationType ?? NotificationType.Error;
         var fail = ServiceResult<T>.Fail(message, code, failType);

--- a/SAPAssistant/Service/UserDashboardService.cs
+++ b/SAPAssistant/Service/UserDashboardService.cs
@@ -2,6 +2,9 @@ using SAPAssistant.Models;
 using System.Net.Http.Json;
 using SAPAssistant.Exceptions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Localization;
+using SAPAssistant;
+using SAPAssistant.Constants;
 using SAPAssistant.Service.Interfaces;
 
 namespace SAPAssistant.Service
@@ -11,12 +14,17 @@ namespace SAPAssistant.Service
         private readonly HttpClient _http;
         private readonly SessionContextService _sessionContext;
         private readonly ILogger<UserDashboardService> _logger;
+        private readonly IStringLocalizer<ErrorMessages> _localizer;
 
-        public UserDashboardService(HttpClient http, SessionContextService sessionContext, ILogger<UserDashboardService> logger)
+        public UserDashboardService(HttpClient http,
+                                    SessionContextService sessionContext,
+                                    ILogger<UserDashboardService> logger,
+                                    IStringLocalizer<ErrorMessages> localizer)
         {
             _http = http;
             _sessionContext = sessionContext;
             _logger = logger;
+            _localizer = localizer;
         }
 
         public async Task<ServiceResult> AddKpiAsync(DashboardCardModel kpi)
@@ -26,8 +34,9 @@ namespace SAPAssistant.Service
                 var userId = await _sessionContext.GetUserIdAsync();
                 if (string.IsNullOrWhiteSpace(userId))
                 {
+                    const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
                     _logger.LogError("Usuario no encontrado en la sesión.");
-                    return ServiceResult.Fail("Usuario no encontrado en la sesión.", "SESSION-USER-NOT-FOUND");
+                    return ServiceResult.Fail(_localizer[code], code);
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Post, "/user-dashboard/kpis");
@@ -47,7 +56,8 @@ namespace SAPAssistant.Service
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error al agregar KPI");
-                return ServiceResult.Fail("Error al agregar KPI");
+                const string code = ErrorCodes.UNEXPECTED_ERROR;
+                return ServiceResult.Fail(_localizer[code], code);
             }
         }
     }

--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using SAPAssistant.Exceptions;
 using Microsoft.Extensions.Localization;
 using SAPAssistant;
+using SAPAssistant.Constants;
 
 namespace SAPAssistant.ViewModels;
 
@@ -83,7 +84,7 @@ public partial class ChatViewModel : BaseViewModel
             {
                 Id = Guid.NewGuid().ToString(),
                 Fecha = DateTime.Now,
-                Titulo = _localizer["NEW-CHAT-TITLE"]
+                Titulo = _localizer[ErrorCodes.NEW_CHAT_TITLE]
             };
         }
 


### PR DESCRIPTION
## Summary
- centralize error and status codes in a new `ErrorCodes` helper
- refactor services and view models to use `ErrorCodes` constants
- align localization keys and add translations for new codes

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689b7f0dd9e483209f14afd887db00d9