### PR TITLE
Log network errors and test logger usage

### DIFF
--- a/SAPAssistant.Tests/ChatHistoryServiceTests.cs
+++ b/SAPAssistant.Tests/ChatHistoryServiceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using SAPAssistant.Constants;
+using SAPAssistant.Service;
+using Xunit;
+
+namespace SAPAssistant.Tests;
+
+public class ChatHistoryServiceTests
+{
+    [Fact]
+    public async Task GetChatSessionAsync_LogsError_OnHttpRequestException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Network"));
+
+        var http = new HttpClient(handler.Object) { BaseAddress = new Uri("http://localhost") };
+        var session = SessionContextFactory.CreateWithDefaults();
+
+        var logger = new Mock<ILogger<ChatHistoryService>>();
+        var localizer = new Mock<IStringLocalizer<ErrorMessages>>();
+        localizer.Setup(l => l[It.IsAny<string>()]).Returns<string>(s => new LocalizedString(s, s));
+
+        var svc = new ChatHistoryService(http, session, logger.Object, localizer.Object);
+
+        await svc.GetChatSessionAsync("chat1");
+
+        logger.Verify(l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("obtener el chat")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()
+            ), Times.Once);
+    }
+}

--- a/SAPAssistant.Tests/ConnectionServiceTests.cs
+++ b/SAPAssistant.Tests/ConnectionServiceTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using SAPAssistant.Constants;
+using SAPAssistant.Service;
+using Xunit;
+
+namespace SAPAssistant.Tests;
+
+public class ConnectionServiceTests
+{
+    [Fact]
+    public async Task GetConnectionsAsync_LogsError_OnHttpRequestException()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Network"));
+
+        var http = new HttpClient(handler.Object) { BaseAddress = new Uri("http://localhost") };
+        var session = SessionContextFactory.CreateWithDefaults();
+
+        var logger = new Mock<ILogger<ConnectionService>>();
+        var localizer = new Mock<IStringLocalizer<ErrorMessages>>();
+        localizer.Setup(l => l[It.IsAny<string>()]).Returns<string>(s => new LocalizedString(s, s));
+
+        var svc = new ConnectionService(http, session, logger.Object, localizer.Object);
+
+        await svc.GetConnectionsAsync();
+
+        logger.Verify(l => l.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("obtener conexiones")),
+                It.IsAny<HttpRequestException>(),
+                It.IsAny<Func<It.IsAnyType, Exception, string>>()
+            ), Times.Once);
+    }
+}

--- a/SAPAssistant.Tests/SAPAssistant.Tests.csproj
+++ b/SAPAssistant.Tests/SAPAssistant.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SAPAssistant\SAPAssistant.csproj" />
+  </ItemGroup>
+</Project>

--- a/SAPAssistant.Tests/TestHelpers.cs
+++ b/SAPAssistant.Tests/TestHelpers.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.AspNetCore.DataProtection;
+using SAPAssistant.Service;
+
+namespace SAPAssistant.Tests;
+
+public class TestJSRuntime : IJSRuntime
+{
+    private readonly ConcurrentDictionary<string, object?> _storage = new();
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+        => InvokeAsync<TValue>(identifier, CancellationToken.None, args);
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+    {
+        if (identifier.Contains("get", StringComparison.OrdinalIgnoreCase))
+        {
+            var key = args![0]!.ToString()!;
+            if (_storage.TryGetValue(key, out var value) && value is not null)
+            {
+                return ValueTask.FromResult((TValue)value);
+            }
+            return ValueTask.FromResult(default(TValue)!);
+        }
+        if (identifier.Contains("set", StringComparison.OrdinalIgnoreCase))
+        {
+            var key = args![0]!.ToString()!;
+            _storage[key] = args![1];
+        }
+        if (identifier.Contains("delete", StringComparison.OrdinalIgnoreCase))
+        {
+            var key = args![0]!.ToString()!;
+            _storage.TryRemove(key, out _);
+        }
+        return ValueTask.FromResult(default(TValue)!);
+    }
+}
+
+public static class SessionContextFactory
+{
+    public static SessionContextService CreateWithDefaults(string? token = "token", string? userId = "user", string? remoteUrl = "remote")
+    {
+        var js = new TestJSRuntime();
+        var protector = new EphemeralDataProtectionProvider().CreateProtector("Test");
+        var storage = new ProtectedSessionStorage(js, protector);
+        if (token != null) storage.SetAsync("token", token).GetAwaiter().GetResult();
+        if (userId != null) storage.SetAsync("username", userId).GetAwaiter().GetResult();
+        if (remoteUrl != null) storage.SetAsync("remote_url", remoteUrl).GetAwaiter().GetResult();
+        return new SessionContextService(storage);
+    }
+}

--- a/SAPAssistant.sln
+++ b/SAPAssistant.sln
@@ -5,17 +5,23 @@ VisualStudioVersion = 17.8.34511.84
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAPAssistant", "SAPAssistant\SAPAssistant.csproj", "{A7BA29FE-170B-447E-B71D-C8F49D5346D7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SAPAssistant.Tests", "SAPAssistant.Tests\SAPAssistant.Tests.csproj", "{7572109A-7E6E-4B15-9B41-0D0252A63E39}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+        GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                {A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {A7BA29FE-170B-447E-B71D-C8F49D5346D7}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7572109A-7E6E-4B15-9B41-0D0252A63E39}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7572109A-7E6E-4B15-9B41-0D0252A63E39}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7572109A-7E6E-4B15-9B41-0D0252A63E39}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7572109A-7E6E-4B15-9B41-0D0252A63E39}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/SAPAssistant/Service/ChatHistoryService.cs
+++ b/SAPAssistant/Service/ChatHistoryService.cs
@@ -97,8 +97,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CHAT_FETCH_SUCCESS;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "[ChatService] Error de red al obtener el chat '{ChatId}'", chatId);
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<ChatSession>.Fail(_localizer[code], code);
             }

--- a/SAPAssistant/Service/ConnectionService.cs
+++ b/SAPAssistant/Service/ConnectionService.cs
@@ -73,8 +73,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CONNECTIONS_FETCH_SUCCESS;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "Error de red al obtener conexiones");
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
             }
@@ -121,8 +122,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CONNECTION_FETCH_SUCCESS;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "Error de red al obtener conexión {ConnectionId}", connectionId);
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
             }
@@ -163,8 +165,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CONNECTION_UPDATED;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "Error de red al actualizar conexión {ConnectionId}", connection.ConnectionId);
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
@@ -205,8 +208,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CONNECTION_CREATED;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "Error de red al crear conexión");
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }
@@ -250,8 +254,9 @@ namespace SAPAssistant.Service
                 ok.ErrorCode = ErrorCodes.CONNECTION_VALID;
                 return ok;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
+                _logger.LogError(ex, "Error de red al validar conexión {ConnectionId}", connectionId);
                 const string code = ErrorCodes.NET_ERROR;
                 return ServiceResult.Fail(_localizer[code], code);
             }


### PR DESCRIPTION
## Summary
- log HttpRequestException failures with contextual messages in connection and chat history services
- cover logger invocation on network errors with unit tests

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689b8255ad388320a109d75933ec6091