### PR TITLE
Implement secure cookie-based auth with remember me option

### DIFF
--- a/SAPAssistant.Tests/SAPAssistant.Tests.csproj
+++ b/SAPAssistant.Tests/SAPAssistant.Tests.csproj
@@ -11,7 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SAPAssistant\SAPAssistant.csproj" />

--- a/SAPAssistant.Tests/TestHelpers.cs
+++ b/SAPAssistant.Tests/TestHelpers.cs
@@ -1,56 +1,21 @@
-using System;
-using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.JSInterop;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Http;
 using SAPAssistant.Service;
+using System.Collections.Generic;
 
 namespace SAPAssistant.Tests;
 
-public class TestJSRuntime : IJSRuntime
-{
-    private readonly ConcurrentDictionary<string, object?> _storage = new();
-
-    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
-        => InvokeAsync<TValue>(identifier, CancellationToken.None, args);
-
-    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
-    {
-        if (identifier.Contains("get", StringComparison.OrdinalIgnoreCase))
-        {
-            var key = args![0]!.ToString()!;
-            if (_storage.TryGetValue(key, out var value) && value is not null)
-            {
-                return ValueTask.FromResult((TValue)value);
-            }
-            return ValueTask.FromResult(default(TValue)!);
-        }
-        if (identifier.Contains("set", StringComparison.OrdinalIgnoreCase))
-        {
-            var key = args![0]!.ToString()!;
-            _storage[key] = args![1];
-        }
-        if (identifier.Contains("delete", StringComparison.OrdinalIgnoreCase))
-        {
-            var key = args![0]!.ToString()!;
-            _storage.TryRemove(key, out _);
-        }
-        return ValueTask.FromResult(default(TValue)!);
-    }
-}
-
+#nullable enable
 public static class SessionContextFactory
 {
     public static SessionContextService CreateWithDefaults(string? token = "token", string? userId = "user", string? remoteUrl = "remote")
     {
-        var js = new TestJSRuntime();
-        var protector = new EphemeralDataProtectionProvider().CreateProtector("Test");
-        var storage = new ProtectedSessionStorage(js, protector);
-        if (token != null) storage.SetAsync("token", token).GetAwaiter().GetResult();
-        if (userId != null) storage.SetAsync("username", userId).GetAwaiter().GetResult();
-        if (remoteUrl != null) storage.SetAsync("remote_url", remoteUrl).GetAwaiter().GetResult();
-        return new SessionContextService(storage);
+        var context = new DefaultHttpContext();
+        var cookies = new List<string>();
+        if (token != null) cookies.Add($"token={token}");
+        if (userId != null) cookies.Add($"username={userId}");
+        if (remoteUrl != null) cookies.Add($"remote_url={remoteUrl}");
+        context.Request.Headers["Cookie"] = string.Join("; ", cookies);
+        var accessor = new HttpContextAccessor { HttpContext = context };
+        return new SessionContextService(accessor);
     }
 }

--- a/SAPAssistant/Pages/Login.razor
+++ b/SAPAssistant/Pages/Login.razor
@@ -60,6 +60,12 @@
                     </button>
                 </div>
 
+                <!-- Recordarme -->
+                <label class="flex items-center gap-2 text-sm">
+                    <InputCheckbox @bind-Value="VM.RememberMe" />
+                    <span>Recordarme</span>
+                </label>
+
                 <!-- Botón de Login -->
                 <button type="submit"
                         class="button-primary"

--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.AspNetCore.Components.Web;
 using SAPAssistant.Security;
 using SAPAssistant.Service;
@@ -58,7 +57,7 @@ builder.Services.AddHttpClient<ApiClient>(client =>
 
 // Resto de servicios de la app
 builder.Services.AddScoped<AuthService>();
-builder.Services.AddScoped<ProtectedSessionStorage>();
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddScoped<SessionContextService>();
 builder.Services.AddScoped<AuthenticationStateProvider, CustomAuthStateProvider>();
 builder.Services.AddScoped<CustomAuthStateProvider>();

--- a/SAPAssistant/Security/CustomAuthStateProvider.cs
+++ b/SAPAssistant/Security/CustomAuthStateProvider.cs
@@ -47,10 +47,10 @@ namespace SAPAssistant.Security
         }
 
 
-        public async Task MarkUserAsAuthenticated(string username, string token)
+        public async Task MarkUserAsAuthenticated(string username, string token, bool persistent = false)
         {
-            await _sessionContext.SetUserIdAsync(username);
-            await _sessionContext.SetTokenAsync(token);
+            await _sessionContext.SetUserIdAsync(username, persistent);
+            await _sessionContext.SetTokenAsync(token, persistent);
 
             var identity = new ClaimsIdentity(new[]
             {
@@ -60,9 +60,9 @@ namespace SAPAssistant.Security
             var user = new ClaimsPrincipal(identity);
             NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
         }
-        public async Task SaveRemoteUrlAsync(string remoteUrl)
+        public async Task SaveRemoteUrlAsync(string remoteUrl, bool persistent = false)
         {
-            await _sessionContext.SetRemoteIpAsync(remoteUrl);
+            await _sessionContext.SetRemoteIpAsync(remoteUrl, persistent);
         }
         public async Task<string?> GetRemoteUrlAsync()
         {

--- a/SAPAssistant/Service/AuthService.cs
+++ b/SAPAssistant/Service/AuthService.cs
@@ -21,7 +21,7 @@ namespace SAPAssistant.Service
             _localizer = localizer;
         }
 
-        public async Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request, CancellationToken ct = default)
+        public async Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request, bool rememberMe = false, CancellationToken ct = default)
         {
             var r = await _api.PostAsResultAsync<LoginRequest, LoginResponse>(
                 "login",            // SIN /api/v1/ porque ya va en BaseAddress
@@ -32,8 +32,8 @@ namespace SAPAssistant.Service
 
             if (r.Success && r.Data is not null)
             {
-                await _authProvider.MarkUserAsAuthenticated(r.Data.Username, r.Data.Token);
-                await _authProvider.SaveRemoteUrlAsync(r.Data.remote_url);
+                await _authProvider.MarkUserAsAuthenticated(r.Data.Username, r.Data.Token, rememberMe);
+                await _authProvider.SaveRemoteUrlAsync(r.Data.remote_url, rememberMe);
             }
             return r;
         }

--- a/SAPAssistant/Service/SessionContextService.cs
+++ b/SAPAssistant/Service/SessionContextService.cs
@@ -1,91 +1,108 @@
-using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Microsoft.AspNetCore.Http;
 using SAPAssistant.Models;
+using System.Text.Json;
 
 namespace SAPAssistant.Service
 {
     public class SessionContextService
     {
-        private readonly ProtectedSessionStorage _sessionStorage;
+        private readonly IHttpContextAccessor _httpContextAccessor;
 
-        public SessionContextService(ProtectedSessionStorage sessionStorage)
+        public SessionContextService(IHttpContextAccessor httpContextAccessor)
         {
-            _sessionStorage = sessionStorage;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        private HttpRequest? Request => _httpContextAccessor.HttpContext?.Request;
+        private HttpResponse? Response => _httpContextAccessor.HttpContext?.Response;
+
+        private CookieOptions BuildOptions(bool persistent = false)
+        {
+            var options = new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.Strict
+            };
+            if (persistent)
+            {
+                options.Expires = DateTimeOffset.UtcNow.AddDays(30);
+            }
+            return options;
+        }
+
+        private string? GetCookie(string key)
+            => Request?.Cookies.TryGetValue(key, out var value) == true ? value : null;
+
+        private ValueTask SetCookie(string key, string value, bool persistent = false)
+        {
+            Response?.Cookies.Append(key, value, BuildOptions(persistent));
+            return ValueTask.CompletedTask;
+        }
+
+        private ValueTask DeleteCookie(string key)
+        {
+            Response?.Cookies.Delete(key);
+            return ValueTask.CompletedTask;
         }
 
         // ----- Autenticación -----
-        public async Task<string?> GetUserIdAsync()
+        public Task<string?> GetUserIdAsync() => Task.FromResult(GetCookie("username"));
+
+        public ValueTask SetUserIdAsync(string username, bool persistent = false)
+            => SetCookie("username", username, persistent);
+
+        public ValueTask DeleteUserIdAsync() => DeleteCookie("username");
+
+        public Task<string?> GetTokenAsync() => Task.FromResult(GetCookie("token"));
+
+        public ValueTask SetTokenAsync(string token, bool persistent = false)
+            => SetCookie("token", token, persistent);
+
+        public ValueTask DeleteTokenAsync() => DeleteCookie("token");
+
+        public Task<string?> GetRemoteIpAsync()
         {
-            var result = await _sessionStorage.GetAsync<string>("username");
-            return result.Success ? result.Value : null;
+            var value = GetCookie("remote_url");
+            return Task.FromResult(value?.TrimEnd('/'));
         }
 
-        public ValueTask SetUserIdAsync(string username)
-            => _sessionStorage.SetAsync("username", username);
+        public ValueTask SetRemoteIpAsync(string remoteUrl, bool persistent = false)
+            => SetCookie("remote_url", remoteUrl, persistent);
 
-        public ValueTask DeleteUserIdAsync()
-            => _sessionStorage.DeleteAsync("username");
-
-        public async Task<string?> GetTokenAsync()
-        {
-            var result = await _sessionStorage.GetAsync<string>("token");
-            return result.Success ? result.Value : null;
-        }
-
-        public ValueTask SetTokenAsync(string token)
-            => _sessionStorage.SetAsync("token", token);
-
-        public ValueTask DeleteTokenAsync()
-            => _sessionStorage.DeleteAsync("token");
-
-        public async Task<string?> GetRemoteIpAsync()
-        {
-            var result = await _sessionStorage.GetAsync<string>("remote_url");
-            return result.Success ? result.Value?.TrimEnd('/') : null;
-        }
-
-        public ValueTask SetRemoteIpAsync(string remoteUrl)
-            => _sessionStorage.SetAsync("remote_url", remoteUrl);
-
-        public ValueTask DeleteRemoteIpAsync()
-            => _sessionStorage.DeleteAsync("remote_url");
+        public ValueTask DeleteRemoteIpAsync() => DeleteCookie("remote_url");
 
         // ----- Conexión activa -----
-        public async Task<string?> GetActiveConnectionIdAsync()
-        {
-            var result = await _sessionStorage.GetAsync<string>("active_connection_id");
-            return result.Success ? result.Value : null;
-        }
+        public Task<string?> GetActiveConnectionIdAsync()
+            => Task.FromResult(GetCookie("active_connection_id"));
 
         public ValueTask SetActiveConnectionIdAsync(string connectionId)
-            => _sessionStorage.SetAsync("active_connection_id", connectionId);
+            => SetCookie("active_connection_id", connectionId);
 
         public ValueTask DeleteActiveConnectionIdAsync()
-            => _sessionStorage.DeleteAsync("active_connection_id");
+            => DeleteCookie("active_connection_id");
 
-        public async Task<string?> GetDatabaseTypeAsync()
-        {
-            var result = await _sessionStorage.GetAsync<string>("active_db_type");
-            return result.Success ? result.Value : null;
-        }
+        public Task<string?> GetDatabaseTypeAsync()
+            => Task.FromResult(GetCookie("active_db_type"));
 
         public ValueTask SetDatabaseTypeAsync(string dbType)
-            => _sessionStorage.SetAsync("active_db_type", dbType);
+            => SetCookie("active_db_type", dbType);
 
         public ValueTask DeleteDatabaseTypeAsync()
-            => _sessionStorage.DeleteAsync("active_db_type");
+            => DeleteCookie("active_db_type");
 
         // ----- Edición de conexión -----
         public async Task<ConnectionDTO?> GetConnectionToEditAsync()
         {
-            var result = await _sessionStorage.GetAsync<ConnectionDTO>("connection_to_edit");
-            return result.Success ? result.Value : null;
+            var json = GetCookie("connection_to_edit");
+            return json is null ? null : JsonSerializer.Deserialize<ConnectionDTO>(json);
         }
 
         public ValueTask SetConnectionToEditAsync(ConnectionDTO connection)
-            => _sessionStorage.SetAsync("connection_to_edit", connection);
+            => SetCookie("connection_to_edit", JsonSerializer.Serialize(connection));
 
         public ValueTask DeleteConnectionToEditAsync()
-            => _sessionStorage.DeleteAsync("connection_to_edit");
+            => DeleteCookie("connection_to_edit");
     }
 }
 

--- a/SAPAssistant/ViewModels/LoginViewModel.cs
+++ b/SAPAssistant/ViewModels/LoginViewModel.cs
@@ -29,6 +29,9 @@ public partial class LoginViewModel : BaseViewModel
     [ObservableProperty]
     private bool showPassword;
 
+    [ObservableProperty]
+    private bool rememberMe;
+
     //public bool CanSubmit =>
     //    !string.IsNullOrWhiteSpace(LoginModel.Username) &&
     //    !string.IsNullOrWhiteSpace(LoginModel.Password);
@@ -61,7 +64,7 @@ public partial class LoginViewModel : BaseViewModel
                 return; // no toasts; feedback inline
 
             // 2) Llamada al servicio (ya devuelve ServiceResult sin lanzar)
-            var result = await _authService.LoginAsync(LoginModel);
+            var result = await _authService.LoginAsync(LoginModel, RememberMe);
 
             if (result.Success)
             {


### PR DESCRIPTION
## Summary
- replace session storage with HttpOnly, Secure cookies and SameSite=Strict
- add optional "Recordarme" checkbox to persist login
- update custom auth provider and services to read identity from cookies

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689cc4e40c848320a6a24ffa6bcff6ab