### PR TITLE
Support ReturnUrl for login redirects

### DIFF
--- a/SAPAssistant/Service/StateContainer.cs
+++ b/SAPAssistant/Service/StateContainer.cs
@@ -25,5 +25,11 @@ namespace SAPAssistant.Service
         /// </summary>
         [ObservableProperty]
         private ChatSession? currentChat;
+
+        /// <summary>
+        /// URL a la que se redirige tras autenticarse.
+        /// </summary>
+        [ObservableProperty]
+        private string? returnUrl;
     }
 }

--- a/SAPAssistant/ViewModels/LoginViewModel.cs
+++ b/SAPAssistant/ViewModels/LoginViewModel.cs
@@ -4,6 +4,7 @@ using SAPAssistant.Models;
 using SAPAssistant.Exceptions;
 using SAPAssistant.Service;
 using SAPAssistant.Service.Interfaces;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace SAPAssistant.ViewModels;
 
@@ -69,7 +70,23 @@ public partial class LoginViewModel : BaseViewModel
             if (result.Success)
             {
                 _stateContainer.AuthenticatedUser = result.Data;
-                _navigation.NavigateTo("/chat");
+
+                var uri = new Uri(_navigation.Uri);
+                var query = QueryHelpers.ParseQuery(uri.Query);
+                string? returnUrl = null;
+
+                if (query.TryGetValue("ReturnUrl", out var url) ||
+                    query.TryGetValue("returnUrl", out url))
+                {
+                    returnUrl = url.ToString();
+                }
+
+                if (string.IsNullOrWhiteSpace(returnUrl))
+                {
+                    returnUrl = _stateContainer.ReturnUrl;
+                }
+
+                _navigation.NavigateTo(string.IsNullOrWhiteSpace(returnUrl) ? "/dashboard" : returnUrl);
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Redirect after login using a configurable ReturnUrl from query string or state container, defaulting to dashboard
- Store ReturnUrl in shared StateContainer

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_689ccae219a48320b203ca8997a1baee