### PR TITLE
Add security headers middleware

### DIFF
--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -120,6 +120,15 @@ var localizationOptions = new RequestLocalizationOptions
 };
 app.UseRequestLocalization(localizationOptions);
 
+app.Use(async (context, next) =>
+{
+    context.Response.Headers["Content-Security-Policy"] =
+        "default-src 'self'; script-src 'self'; style-src 'self'; frame-ancestors 'none';";
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    context.Response.Headers["X-Frame-Options"] = "DENY";
+    await next();
+});
+
 app.UseRouting();
 
 app.MapGet("/csrf-token", (HttpContext context, IAntiforgery antiforgery) =>


### PR DESCRIPTION
## Summary
- add middleware to set CSP, X-Content-Type-Options and X-Frame-Options headers

## Testing
- `dotnet test`
- `curl -I http://localhost:5000/login`


------
https://chatgpt.com/codex/tasks/task_e_689ccd33800883209932bfd62270c96b