### PR TITLE
Allow CDN resources in CSP

### DIFF
--- a/SAPAssistant/appsettings.json
+++ b/SAPAssistant/appsettings.json
@@ -12,13 +12,18 @@
       "'self'"
     ],
     "ScriptSrc": [
-      "'self'"
+      "'self'",
+      "https://cdn.jsdelivr.net"
     ],
     "StyleSrc": [
-      "'self'"
+      "'self'",
+      "https://cdn.jsdelivr.net",
+      "https://fonts.googleapis.com"
     ],
     "FontSrc": [
-      "'self'"
+      "'self'",
+      "https://cdn.jsdelivr.net",
+      "https://fonts.gstatic.com"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- permit JS scripts from cdn.jsdelivr.net
- allow styles from cdn.jsdelivr.net and fonts.googleapis.com
- allow font loading from cdn.jsdelivr.net and fonts.gstatic.com

## Testing
- `dotnet test`
- `dotnet run --project SAPAssistant/SAPAssistant.csproj` (started server)


------
https://chatgpt.com/codex/tasks/task_e_689d01319ba48320b669bde4e3b4fb82