### PR TITLE
Handle cookies after response started

### DIFF
--- a/SAPAssistant/Security/CustomAuthStateProvider.cs
+++ b/SAPAssistant/Security/CustomAuthStateProvider.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using SAPAssistant.Service;
 using System.Security.Claims;
+using Microsoft.JSInterop;
 
 namespace SAPAssistant.Security
 {
@@ -47,10 +48,10 @@ namespace SAPAssistant.Security
         }
 
 
-        public async Task MarkUserAsAuthenticated(string username, string token, bool persistent = false)
+        public async Task MarkUserAsAuthenticated(string username, string token, bool persistent = false, IJSRuntime? js = null)
         {
-            await _sessionContext.SetUserIdAsync(username, persistent);
-            await _sessionContext.SetTokenAsync(token, persistent);
+            await _sessionContext.SetUserIdAsync(username, persistent, js);
+            await _sessionContext.SetTokenAsync(token, persistent, js);
 
             var identity = new ClaimsIdentity(new[]
             {
@@ -60,9 +61,9 @@ namespace SAPAssistant.Security
             var user = new ClaimsPrincipal(identity);
             NotifyAuthenticationStateChanged(Task.FromResult(new AuthenticationState(user)));
         }
-        public async Task SaveRemoteUrlAsync(string remoteUrl, bool persistent = false)
+        public async Task SaveRemoteUrlAsync(string remoteUrl, bool persistent = false, IJSRuntime? js = null)
         {
-            await _sessionContext.SetRemoteIpAsync(remoteUrl, persistent);
+            await _sessionContext.SetRemoteIpAsync(remoteUrl, persistent, js);
         }
         public async Task<string?> GetRemoteUrlAsync()
         {

--- a/SAPAssistant/Service/AuthService.cs
+++ b/SAPAssistant/Service/AuthService.cs
@@ -4,6 +4,7 @@ using SAPAssistant.Security;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Localization;
 using SAPAssistant.Constants;
+using Microsoft.JSInterop;
 
 
 namespace SAPAssistant.Service
@@ -13,12 +14,14 @@ namespace SAPAssistant.Service
         private readonly ApiClient _api;
         private readonly CustomAuthStateProvider _authProvider;
         private readonly IStringLocalizer<ErrorMessages> _localizer;
+        private readonly IJSRuntime _js;
 
-        public AuthService(ApiClient api, CustomAuthStateProvider authProvider, IStringLocalizer<ErrorMessages> localizer)
+        public AuthService(ApiClient api, CustomAuthStateProvider authProvider, IStringLocalizer<ErrorMessages> localizer, IJSRuntime js)
         {
             _api = api;
             _authProvider = authProvider;
             _localizer = localizer;
+            _js = js;
         }
 
         public async Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request, bool rememberMe = false, CancellationToken ct = default)
@@ -32,8 +35,8 @@ namespace SAPAssistant.Service
 
             if (r.Success && r.Data is not null)
             {
-                await _authProvider.MarkUserAsAuthenticated(r.Data.Username, r.Data.Token, rememberMe);
-                await _authProvider.SaveRemoteUrlAsync(r.Data.remote_url, rememberMe);
+                await _authProvider.MarkUserAsAuthenticated(r.Data.Username, r.Data.Token, rememberMe, _js);
+                await _authProvider.SaveRemoteUrlAsync(r.Data.remote_url, rememberMe, _js);
             }
             return r;
         }

--- a/SAPAssistant/wwwroot/js/scripts.js
+++ b/SAPAssistant/wwwroot/js/scripts.js
@@ -1,7 +1,16 @@
-﻿window.scrollToId = function (id) {
+window.scrollToId = function (id) {
     const el = document.getElementById(id);
     if (el) {
         el.scrollIntoView({ behavior: 'smooth' });
     }
 };
 
+window.setCookie = function (key, value, days) {
+    let expires = "";
+    if (days) {
+        const date = new Date();
+        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+        expires = "; expires=" + date.toUTCString();
+    }
+    document.cookie = key + "=" + value + expires + "; path=/; SameSite=Strict; Secure";
+};


### PR DESCRIPTION
## Summary
- Avoid writing cookies after the HTTP response starts
- Set cookies from client using JS when needed
- Inject JS runtime into auth flow to store login cookies

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689d068c18c48320a3f0de63695da47e