### PR TITLE
Move view type preference script to external file

### DIFF
--- a/SAPAssistant/Pages/_Host.cshtml
+++ b/SAPAssistant/Pages/_Host.cshtml
@@ -80,18 +80,8 @@
         };
     </script>
 
-    <script>
-        window.viewTypePref = {
-            set: function (value) {
-                localStorage.setItem('preferred_view_type', value);
-            },
-            get: function () {
-                return localStorage.getItem('preferred_view_type');
-            }
-        };
-    </script>
+    <script src="js/view-type-pref.js"></script>
 
-        
     <script src="_content/MudBlazor/MudBlazor.min.js?v=8.9.0"></script>
     <script src="https://cdn.jsdelivr.net/npm/interactjs/dist/interact.min.js"></script>
     <script src="js/dashboard.js"></script>

--- a/SAPAssistant/wwwroot/js/view-type-pref.js
+++ b/SAPAssistant/wwwroot/js/view-type-pref.js
@@ -1,0 +1,9 @@
+window.viewTypePref = {
+    set: function (value) {
+        localStorage.setItem('preferred_view_type', value);
+    },
+    get: function () {
+        return localStorage.getItem('preferred_view_type');
+    }
+};
+


### PR DESCRIPTION
## Summary
- define viewTypePref helper in new `wwwroot/js/view-type-pref.js`
- load `view-type-pref.js` from `_Host.cshtml` instead of inline script

## Testing
- `dotnet test`
- `curl -I http://localhost:5062/`
- `curl http://localhost:5062/ | rg 'view-type-pref'`


------
https://chatgpt.com/codex/tasks/task_e_689d0d603aa483208bf75e7311bb7f2e