### PR TITLE
Remove cookie-based user and token handling

### DIFF
--- a/SAPAssistant/Service/AssistantService.cs
+++ b/SAPAssistant/Service/AssistantService.cs
@@ -25,8 +25,6 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var username = await _sessionContext.GetUserIdAsync() ??
-                    throw new AssistantException("Usuario no autenticado", "UNAUTHENTICATED");
                 var connectionId = await _sessionContext.GetActiveConnectionIdAsync() ??
                     throw new AssistantException("No hay conexión activa", "NO_ACTIVE_CONNECTION");
                 var remoteIp = await _sessionContext.GetRemoteIpAsync() ??
@@ -48,7 +46,6 @@ namespace SAPAssistant.Service
                     })
                 };
 
-                request.Headers.Add("X-User-Id", username);
                 request.Headers.Add("x-remote-ip", remoteIp);
 
                 var response = await SendAndParseAsync(request);

--- a/SAPAssistant/Service/ConnectionService.cs
+++ b/SAPAssistant/Service/ConnectionService.cs
@@ -1,6 +1,5 @@
 ﻿using SAPAssistant.Models;
 using System.Net.Http.Json;
-using SAPAssistant.Exceptions;
 using SAPAssistant.Mapper;
 using Microsoft.Extensions.Logging;
 using SAPAssistant.Service.Interfaces;
@@ -33,21 +32,7 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var token = await _sessionContext.GetTokenAsync();
-                var userId = await _sessionContext.GetUserIdAsync();
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
-
-                if (string.IsNullOrWhiteSpace(token))
-                {
-                    const string code = ErrorCodes.SESSION_TOKEN_NOT_FOUND;
-                    return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
-                }
-
-                if (string.IsNullOrWhiteSpace(userId))
-                {
-                    const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
-                    return ServiceResult<List<ConnectionDTO>>.Fail(_localizer[code], code);
-                }
 
                 if (string.IsNullOrWhiteSpace(remoteIp))
                 {
@@ -56,7 +41,6 @@ namespace SAPAssistant.Service
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Get, "/connection/user-connections");
-                request.Headers.Add("X-User-Id", userId);
                 request.Headers.Add("x-remote-ip", remoteIp);
 
                 var response = await _http.SendAsync(request);
@@ -91,17 +75,14 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var userId = await _sessionContext.GetUserIdAsync();
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
-
-                if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
+                if (string.IsNullOrWhiteSpace(remoteIp))
                 {
                     const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult<ConnectionDTO>.Fail(_localizer[code], code);
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Get, $"/connection/connections/{connectionId}");
-                request.Headers.Add("X-User-Id", userId);
                 request.Headers.Add("x_remote_ip", remoteIp);
 
                 var response = await _http.SendAsync(request);
@@ -140,17 +121,14 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var userId = await _sessionContext.GetUserIdAsync();
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
-
-                if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
+                if (string.IsNullOrWhiteSpace(remoteIp))
                 {
                     const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Put, $"/connection/connections/{connection.ConnectionId}");
-                request.Headers.Add("X-User-Id", userId);
                 request.Headers.Add("x_remote_ip", remoteIp);
                 request.Content = JsonContent.Create(connection);
 
@@ -183,17 +161,14 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var userId = await _sessionContext.GetUserIdAsync();
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
-
-                if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
+                if (string.IsNullOrWhiteSpace(remoteIp))
                 {
                     const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Post, "/connection/connections");
-                request.Headers.Add("X-User-Id", userId);
                 request.Headers.Add("x_remote_ip", remoteIp);
                 request.Content = JsonContent.Create(connection);
 
@@ -226,16 +201,14 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var userId = await _sessionContext.GetUserIdAsync();
                 var remoteIp = await _sessionContext.GetRemoteIpAsync();
-                if (string.IsNullOrWhiteSpace(userId) || string.IsNullOrWhiteSpace(remoteIp))
+                if (string.IsNullOrWhiteSpace(remoteIp))
                 {
                     const string code = ErrorCodes.SESSION_DATA_NOT_FOUND;
                     return ServiceResult.Fail(_localizer[code], code);
                 }
 
                 var request = new HttpRequestMessage(HttpMethod.Post, $"/connection/connections/{connectionId}/validate");
-                request.Headers.Add("X-User-Id", userId);
                 request.Headers.Add("x-remote-ip", remoteIp);
 
                 var response = await _http.SendAsync(request);

--- a/SAPAssistant/Service/SessionContextService.cs
+++ b/SAPAssistant/Service/SessionContextService.cs
@@ -59,17 +59,7 @@ namespace SAPAssistant.Service
         }
 
         // ----- Autenticación -----
-        public Task<string?> GetUserIdAsync() => Task.FromResult(GetCookie("username"));
-
-        public ValueTask SetUserIdAsync(string username, bool persistent = false, IJSRuntime? js = null)
-            => SetCookie("username", username, persistent, js);
-
         public ValueTask DeleteUserIdAsync() => DeleteCookie("username");
-
-        public Task<string?> GetTokenAsync() => Task.FromResult(GetCookie("token"));
-
-        public ValueTask SetTokenAsync(string token, bool persistent = false, IJSRuntime? js = null)
-            => SetCookie("token", token, persistent, js);
 
         public ValueTask DeleteTokenAsync() => DeleteCookie("token");
 

--- a/SAPAssistant/Service/UserDashboardService.cs
+++ b/SAPAssistant/Service/UserDashboardService.cs
@@ -1,6 +1,5 @@
 using SAPAssistant.Models;
 using System.Net.Http.Json;
-using SAPAssistant.Exceptions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Localization;
 using SAPAssistant;
@@ -31,16 +30,7 @@ namespace SAPAssistant.Service
         {
             try
             {
-                var userId = await _sessionContext.GetUserIdAsync();
-                if (string.IsNullOrWhiteSpace(userId))
-                {
-                    const string code = ErrorCodes.SESSION_USER_NOT_FOUND;
-                    _logger.LogError("Usuario no encontrado en la sesión.");
-                    return ServiceResult.Fail(_localizer[code], code);
-                }
-
                 var request = new HttpRequestMessage(HttpMethod.Post, "/user-dashboard/kpis");
-                request.Headers.Add("X-User-Id", userId);
                 request.Content = JsonContent.Create(kpi);
 
                 var response = await _http.SendAsync(request);


### PR DESCRIPTION
## Summary
- drop GetUserIdAsync and GetTokenAsync methods from session context
- refactor services to no longer depend on user id or token cookies

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e13fd2eec832081b872cd3f40bd34