### PR TITLE
Add security headers to middleware

### DIFF
--- a/SAPAssistant/Program.cs
+++ b/SAPAssistant/Program.cs
@@ -139,6 +139,8 @@ app.UseRequestLocalization(localizationOptions);
 app.Use(async (context, next) =>
 {
     context.Response.Headers["Content-Security-Policy"] = cspBuilder.Build();
+    context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+    context.Response.Headers["X-Frame-Options"] = "DENY";
     await next();
 });
 


### PR DESCRIPTION
## Summary
- add X-Content-Type-Options and X-Frame-Options headers alongside CSP

## Testing
- `dotnet test`
- `curl -I http://localhost:5000/`

------
https://chatgpt.com/codex/tasks/task_e_689edde0e9bc8320969fecdbd41ffa80