### PR TITLE
Fetch CSRF token before login

### DIFF
--- a/SAPAssistant/Pages/Login.razor
+++ b/SAPAssistant/Pages/Login.razor
@@ -85,6 +85,11 @@
 @code {
     private ElementReference usernameInput;
 
+    protected override async Task OnInitializedAsync()
+    {
+        await VM.InitializeAsync();
+    }
+
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)

--- a/SAPAssistant/Service/AuthService.cs
+++ b/SAPAssistant/Service/AuthService.cs
@@ -25,17 +25,18 @@ namespace SAPAssistant.Service
             _sessionContext = sessionContext;
         }
 
-        public async Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request, CancellationToken ct = default)
+        public async Task<ServiceResult<LoginResponse>> LoginAsync(LoginRequest request, string? csrfToken = null, CancellationToken ct = default)
         {
             var client = _httpClientFactory.CreateClient();
             var httpContext = _contextAccessor.HttpContext;
             var baseUri = $"{httpContext?.Request.Scheme}://{httpContext?.Request.Host}";
             client.BaseAddress = new Uri(baseUri);
 
-            var token = httpContext?.Request.Cookies["XSRF-TOKEN"];
+            var token = csrfToken ?? httpContext?.Request.Cookies["XSRF-TOKEN"];
             if (!string.IsNullOrEmpty(token))
             {
                 client.DefaultRequestHeaders.TryAddWithoutValidation("X-CSRF-TOKEN", token);
+                client.DefaultRequestHeaders.TryAddWithoutValidation("Cookie", $"XSRF-TOKEN={token}");
             }
 
             try


### PR DESCRIPTION
## Summary
- Request `/csrf-token` when the login component initializes and store the token in the view model
- Send stored CSRF token on login requests via header and cookie

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689ee216fabc8320bcbd66d5eaf7855e