### PR TITLE
Integrate SSE progress updates

### DIFF
--- a/SAPAssistant/Models/StartResponse.cs
+++ b/SAPAssistant/Models/StartResponse.cs
@@ -1,0 +1,6 @@
+namespace SAPAssistant.Models;
+
+public class StartResponse
+{
+    public string request_id { get; set; } = string.Empty;
+}

--- a/SAPAssistant/Pages/Chat/ChatAssistant.razor
+++ b/SAPAssistant/Pages/Chat/ChatAssistant.razor
@@ -24,7 +24,21 @@
         <SearchBar @bind-SearchText="VM.UserInput" OnSearch="@(msg => VM.SendMessage(msg, false))" Disabled="VM.IsProcessing" />
         @if (VM.IsProcessing)
         {
-            <div class="loading-spinner">⌛ Procesando...</div>
+            <div class="progress-area">
+                <p>@VM.CurrentPhase</p>
+                @if (VM.ProgressValue.HasValue)
+                {
+                    <progress max="1" value="@VM.ProgressValue"></progress>
+                }
+                else
+                {
+                    <progress max="100"></progress>
+                }
+                @if (VM.IsReconnecting)
+                {
+                    <div class="reconnect-msg">Reconectando…</div>
+                }
+            </div>
         }
     </div>
 </div>
@@ -36,6 +50,7 @@
     protected override async Task OnInitializedAsync()
     {
         State.PropertyChanged += HandleStateChanged;
+        VM.StateHasChanged = StateHasChanged;
         await VM.OnInitializedAsync();
     }
 
@@ -49,5 +64,9 @@
         }
     }
 
-    public void Dispose() => State.PropertyChanged -= HandleStateChanged;
+    public void Dispose()
+    {
+        State.PropertyChanged -= HandleStateChanged;
+        VM.DisposeAsync().AsTask().GetAwaiter().GetResult();
+    }
 }

--- a/SAPAssistant/Service/Interfaces/IAssistantService.cs
+++ b/SAPAssistant/Service/Interfaces/IAssistantService.cs
@@ -7,6 +7,7 @@ namespace SAPAssistant.Service.Interfaces
     {
         Task<ServiceResult<QueryResponse>> ConsultarAsync(string mensaje, string chatId);
         Task<ServiceResult<QueryResponse>> ConsultarDemoAsync(string mensaje);
+        Task<ServiceResult<string>> StartQueryAsync(string mensaje, string chatId);
     }
 }
 

--- a/SAPAssistant/wwwroot/progress.js
+++ b/SAPAssistant/wwwroot/progress.js
@@ -1,0 +1,27 @@
+export function connectSSE(requestId, dotNetRef) {
+  let es;
+  let retry = 1000;
+
+  function start() {
+    es = new EventSource(`/progress/sse/${requestId}`);
+    es.onopen = () => dotNetRef.invokeMethodAsync('OnReconnectStateChange', false);
+    es.onmessage = e => dotNetRef.invokeMethodAsync('OnProgressEvent', e.data);
+    es.onerror = () => {
+      dotNetRef.invokeMethodAsync('OnReconnectStateChange', true);
+      es.close();
+      setTimeout(() => {
+        retry = Math.min(retry * 2, 10000);
+        start();
+      }, retry);
+    };
+  }
+
+  start();
+  return es;
+}
+
+export function closeSSE(es) {
+  if (es) {
+    es.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add StartQueryAsync service method and start response model
- wire chat view model to stream progress events via SSE with reconnection
- expose progress status in chat UI and manage client-side SSE module

## Testing
- `dotnet test` *(fails: There is no argument given that corresponds to the required parameter 'sessionStorage' of 'SessionContextService.SessionContextService(...))*

------
https://chatgpt.com/codex/tasks/task_e_68aa42a4e84483208236ffcbba8fe347