### PR TITLE
Dispose SSE event sources on teardown

### DIFF
--- a/SAPAssistant/ViewModels/ChatViewModel.cs
+++ b/SAPAssistant/ViewModels/ChatViewModel.cs
@@ -343,16 +343,18 @@ public partial class ChatViewModel : BaseViewModel, IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_progressModule != null && _eventSource != null)
-        {
-            await _progressModule.InvokeVoidAsync("closeSSE", _eventSource);
-            _eventSource = null;
-        }
         if (_progressModule != null)
         {
+            if (_eventSource != null)
+            {
+                await _progressModule.InvokeVoidAsync("closeSSE", _eventSource);
+                _eventSource = null;
+            }
+
             await _progressModule.DisposeAsync();
             _progressModule = null;
         }
+
         _dotNetRef?.Dispose();
     }
 }

--- a/SAPAssistant/wwwroot/progress.js
+++ b/SAPAssistant/wwwroot/progress.js
@@ -21,7 +21,5 @@ export function connectSSE(requestId, dotNetRef) {
 }
 
 export function closeSSE(es) {
-  if (es) {
-    es.close();
-  }
+  es.close();
 }


### PR DESCRIPTION
## Summary
- Return raw EventSource from progress module and expose close helper
- Dispose active SSE connection when chat view model is disposed

## Testing
- `dotnet test` *(fails: required parameters missing in test constructors)*

------
https://chatgpt.com/codex/tasks/task_e_68aae2f495608320825a0b1617e65955