### PR TITLE
Allow configuring base URL for progress SSE

### DIFF
--- a/SAPAssistant/wwwroot/js/progress.js
+++ b/SAPAssistant/wwwroot/js/progress.js
@@ -1,9 +1,9 @@
-export function connectSSE(requestId, dotNetRef) {
+export function connectSSE(requestId, baseUrl, dotNetRef) {
   let es;
   let retry = 1000;
 
   function start() {
-    es = new EventSource(`/progress/sse/${requestId}`);
+    es = new EventSource(`${baseUrl}/progress/sse/${requestId}`);
     es.onopen = () => dotNetRef.invokeMethodAsync('OnReconnectStateChange', false);
     es.onmessage = e => dotNetRef.invokeMethodAsync('OnProgressEvent', e.data);
     es.onerror = () => {


### PR DESCRIPTION
## Summary
- allow specifying a base URL when connecting to SSE

## Testing
- `dotnet test` *(fails: no argument for required parameter 'sessionStorage')*

------
https://chatgpt.com/codex/tasks/task_e_68aaeb820b1c8320850a158530fa5cb1